### PR TITLE
✨ feat (CHASE Frontend): add 5min label for status timer

### DIFF
--- a/chase/frontend/components/dashboard/chair/set_status.tsx
+++ b/chase/frontend/components/dashboard/chair/set_status.tsx
@@ -42,6 +42,7 @@ export default function SetStatusWidget() {
     useState(false);
 
   const TEMPLATE_TIMER_TIMEFRAMES = [
+    { label: "5", value: 5 * 60 * 1000 },
     { label: "10", value: 10 * 60 * 1000 },
     { label: "15", value: 15 * 60 * 1000 },
     { label: "20", value: 20 * 60 * 1000 },


### PR DESCRIPTION
branch: 113-add-a-status-timer-preset-of-5-minutes

implemented