### PR TITLE
🐞 fix: Decrypt Git Crypt encrypted files and remove FontAwesome Package aspects from repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install all dependencies
         run: bun i
-        env:
-          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
         # typecheck the backend since it is required for the frontend
       - name: Typecheck backend
@@ -51,8 +49,6 @@ jobs:
 
       - name: Install all dependencies
         run: bun i
-        env:
-          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: Typecheck
         working-directory: ./chase/backend

--- a/.github/workflows/build_publish_container_images.yml
+++ b/.github/workflows/build_publish_container_images.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Unlock secrets
+        uses: sliteteam/github-action-git-crypt-unlock@1.2.0
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -32,7 +37,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            FONTAWESOME_NPM_AUTH_TOKEN=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
             NEXT_PUBLIC_VERSION=${{ github.event.release.tag_name }}
 
   chase-backend:

--- a/Dockerfile.chase.backend
+++ b/Dockerfile.chase.backend
@@ -3,7 +3,6 @@
 # install dependencies into temp directory
 # this will cache them and speed up future builds
 FROM oven/bun:latest AS install
-ENV FONTAWESOME_NPM_AUTH_TOKEN $FONTAWESOME_NPM_AUTH_TOKEN
 RUN mkdir -p /temp/dev
 COPY package.json bun.lockb bunfig.toml /temp/dev/
 COPY chase/backend/package.json /temp/dev/chase/backend/package.json

--- a/Dockerfile.chase.frontend
+++ b/Dockerfile.chase.frontend
@@ -1,6 +1,4 @@
 FROM oven/bun:latest AS install
-ARG FONTAWESOME_NPM_AUTH_TOKEN
-RUN export FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}
 COPY package.json bun.lockb bunfig.toml /temp/dev/
 COPY chase/backend/package.json /temp/dev/chase/backend/package.json
 COPY chase/frontend/package.json /temp/dev/chase/frontend/package.json

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[install.scopes]
-"@fortawesome" = { token = "$FONTAWESOME_NPM_AUTH_TOKEN", url = "https://npm.fontawesome.com/" }

--- a/chase/frontend/.npmrc
+++ b/chase/frontend/.npmrc
@@ -1,2 +1,0 @@
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}


### PR DESCRIPTION
branch: 178-new-fontawesome-icon-approach-needs-git-crypt-file-to-be-present-in-the-repository-env-for-actions
