### PR TITLE
Add remaining Trivy CVEs: esbuild Go stdlib + Debian package vulns

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -65,6 +65,18 @@ CVE-2025-47911
 # net/http: request smuggling - esbuild doesn't serve HTTP
 CVE-2025-22871
 
+# crypto/tls: unexpected session resumption - esbuild doesn't do TLS
+CVE-2025-68121
+
+# net/url: memory exhaustion in query parameter parsing - esbuild doesn't parse URLs
+CVE-2025-61726
+
+# archive/zip: excessive CPU building archive index - esbuild doesn't process zip files
+CVE-2025-61728
+
+# crypto/tls: TLS 1.3 handshake multiple messages in records - esbuild doesn't do TLS
+CVE-2025-61730
+
 # Debian system packages - not used by Node.js runtime
 
 # libgnutls30: GnuTLS SAN export - Node.js uses OpenSSL, not GnuTLS
@@ -75,6 +87,12 @@ CVE-2025-32990
 
 # perl-base: CPAN TLS verification - CPAN module installer not used at runtime
 CVE-2023-31484
+
+# gpgv: GnuPG out-of-bounds write - gpg signature verification not used at runtime
+CVE-2025-68973
+
+# libpam: directory traversal - PAM auth not used by Node.js/Bun runtime
+CVE-2025-6020
 
 # TODO: Remove these ignores once fixed
 


### PR DESCRIPTION
esbuild Go stdlib (build tool, doesn't use these features):
- CVE-2025-68121: crypto/tls session resumption (CRITICAL)
- CVE-2025-61726: net/url query parameter memory exhaustion
- CVE-2025-61728: archive/zip CPU exhaustion
- CVE-2025-61730: crypto/tls 1.3 handshake issue

Debian system packages (not used by Node.js/Bun runtime):
- CVE-2025-68973: gpgv out-of-bounds write
- CVE-2025-6020: libpam directory traversal

https://claude.ai/code/session_01269gHNV4xijhe2kdfaRCGi