### PR TITLE
feat: add OS-aware Kbd component for hotkey display

### DIFF
--- a/src/lib/components/Alert/PromiseAlert.svelte
+++ b/src/lib/components/Alert/PromiseAlert.svelte
@@ -3,6 +3,7 @@
 	import { onMount, type Snippet } from 'svelte';
 	import { alertDialogStore } from './alert';
 	import { browser } from '$app/environment';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import hotkeys from 'hotkeys-js';
 	import { fade, fly, scale } from 'svelte/transition';
 
@@ -68,7 +69,7 @@
 							<AlertDialog.Cancel onclick={$alertDialogStore?.onClose} class="btn btn-lg flex-1">
 								<i class="fas fa-xmark"></i>
 								{$alertDialogStore?.cancelText}
-								<span class="kbd kbd-sm"> esc </span>
+								<Kbd hotkey="esc" size="sm" />
 							</AlertDialog.Cancel>
 							<AlertDialog.Action
 								onclick={$alertDialogStore?.onConfirm}
@@ -76,7 +77,7 @@
 							>
 								<i class="fas fa-check"></i>
 								{$alertDialogStore?.confirmText}
-								<span class="kbd kbd-sm text-base-content"> ↵ </span>
+								<Kbd hotkey="enter" size="sm" class="text-base-content" />
 							</AlertDialog.Action>
 						</div>
 					</div>

--- a/src/lib/components/BasicCard.svelte
+++ b/src/lib/components/BasicCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Kbd from './Kbd.svelte';
 
 	interface Props {
 		children: Snippet;
@@ -19,7 +20,7 @@
 					{title}
 
 					{#if kbd}
-						<div class="kbd ml-2">{kbd}</div>
+						<Kbd hotkey={kbd} class="ml-2" />
 					{/if}
 				</h2>
 			</div>

--- a/src/lib/components/Combobox.svelte
+++ b/src/lib/components/Combobox.svelte
@@ -3,6 +3,7 @@
 	import { Combobox } from 'bits-ui';
 	import type { Snippet } from 'svelte';
 	import { crossfade } from 'svelte/transition';
+	import Kbd from './Kbd.svelte';
 
 	interface Props {
 		value: string;
@@ -71,11 +72,9 @@
 						}}
 					/>
 					{#if kbd && !focused}
-						<span class="kbd">
-							{kbd}
-						</span>
+						<Kbd hotkey={kbd} />
 					{:else if kbd}
-						<span class="kbd"> Esc </span>
+						<Kbd hotkey="esc" />
 					{/if}
 				</label>
 			{/snippet}

--- a/src/lib/components/JoinedButtons.svelte
+++ b/src/lib/components/JoinedButtons.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Kbd from './Kbd.svelte';
+
 	interface Props {
 		buttons: Button[];
 	}
@@ -37,7 +39,7 @@
 	{/if}
 	<div class="hidden md:block">{label}</div>
 	{#if shortcut && shortcut !== ''}
-		<div class="kbd bg-base-100 text-base-content hidden md:block">{shortcut}</div>
+		<Kbd hotkey={shortcut} class="bg-base-100 text-base-content hidden md:block" />
 	{/if}
 {/snippet}
 

--- a/src/lib/components/Kbd.svelte
+++ b/src/lib/components/Kbd.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+
+	interface Props {
+		hotkey: string;
+		size?: 'xs' | 'sm';
+		class?: string;
+	}
+
+	let { hotkey, size, class: className }: Props = $props();
+
+	const isMac = browser && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+	const macModifiers: Record<string, string> = {
+		alt: '\u2325',
+		shift: '\u21E7',
+		ctrl: '\u2303',
+		mod: '\u2318',
+		enter: '\u21B5',
+		space: '\u2423',
+		backspace: '\u232B',
+		esc: 'Esc'
+	};
+
+	const nonMacModifiers: Record<string, string> = {
+		alt: 'Alt',
+		shift: 'Shift',
+		ctrl: 'Ctrl',
+		mod: 'Ctrl',
+		enter: '\u21B5',
+		space: '\u2423',
+		backspace: '\u232B',
+		esc: 'Esc'
+	};
+
+	const formatted = $derived(
+		hotkey
+			.split('+')
+			.map((part) => {
+				const key = part.trim().toLowerCase();
+				if (isMac) return macModifiers[key] ?? part.trim();
+				return nonMacModifiers[key] ?? part.trim();
+			})
+			.join(isMac ? '' : '+')
+	);
+</script>
+
+<span class="kbd{size ? ` kbd-${size}` : ''}{className ? ` ${className}` : ''}">{formatted}</span>

--- a/src/lib/components/rollCall/ChairRollCall.svelte
+++ b/src/lib/components/rollCall/ChairRollCall.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { CommitteeTeamQuery$result } from '$houdini';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { onDestroy, onMount } from 'svelte';
 	import Modal from '../Modal.svelte';
@@ -99,7 +100,7 @@
 		>
 			<i class="fas fa-xmark"></i>
 			{m.absent()}
-			<span class="kbd">J</span>
+			<Kbd hotkey="J" />
 		</button>
 		<div class="join">
 			<button
@@ -129,7 +130,7 @@
 		>
 			<i class="fas fa-check"></i>
 			{m.present()}
-			<span class="kbd">L</span>
+			<Kbd hotkey="L" />
 		</button>
 
 		<div class="absolute top-3 right-3">

--- a/src/lib/components/speakersList/chairControls/AddSpeakers.svelte
+++ b/src/lib/components/speakersList/chairControls/AddSpeakers.svelte
@@ -147,7 +147,7 @@
 	filter={(member, value) => filter(member, value)}
 	placeholder="Search for a country"
 	getStringValue={(member) => getName(member)}
-	kbd={speakersList?.type === 'COMMENT_LIST' ? '⌥ ⇧ A' : '⌥ A'}
+	kbd={speakersList?.type === 'COMMENT_LIST' ? 'alt+shift+A' : 'alt+A'}
 	submit={() => addSpeakerToList()}
 >
 	{#snippet ListItem(option)}

--- a/src/lib/components/speakersList/chairControls/NextSpeech.svelte
+++ b/src/lib/components/speakersList/chairControls/NextSpeech.svelte
@@ -5,6 +5,7 @@
 		type SpeakersListCategoryEnum$options
 	} from '$houdini';
 	import { alertDialog } from '$lib/components/Alert/alert';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { promiseToastStrings } from '$lib/utils/toast';
 	import hotkeys from 'hotkeys-js';
@@ -136,11 +137,9 @@
 >
 	<i class="fas fa-diagram-next"></i>
 	{m.nextSpeaker()}
-	<span class="kbd text-base-content">
-		{#if type === 'COMMENT_LIST'}
-			⌥ ⇧ N
-		{:else if type === 'SPEAKERS_LIST'}
-			⌥ N
-		{/if}
-	</span>
+	{#if type === 'COMMENT_LIST'}
+		<Kbd hotkey="alt+shift+N" class="text-base-content" />
+	{:else if type === 'SPEAKERS_LIST'}
+		<Kbd hotkey="alt+N" class="text-base-content" />
+	{/if}
 </button>

--- a/src/lib/components/speakersList/chairControls/SpeechControls.svelte
+++ b/src/lib/components/speakersList/chairControls/SpeechControls.svelte
@@ -4,6 +4,7 @@
 		type CommitteeTeamQuery$result,
 		type SpeakersListCategoryEnum$options
 	} from '$houdini';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { serverTime } from '$lib/state/serverTime.svelte';
 	import dayjs from 'dayjs';
@@ -221,13 +222,11 @@
 			<i class="fas fa-play"></i>
 		{/if}
 		{m.timer()}
-		<span class="kbd text-base-content">
-			{#if type === 'COMMENT_LIST'}
-				⇧ ␣
-			{:else if type === 'SPEAKERS_LIST'}
-				␣
-			{/if}
-		</span>
+		{#if type === 'COMMENT_LIST'}
+			<Kbd hotkey="shift+space" class="text-base-content" />
+		{:else if type === 'SPEAKERS_LIST'}
+			<Kbd hotkey="space" class="text-base-content" />
+		{/if}
 	</button>
 	<div class="join">
 		<button
@@ -244,13 +243,11 @@
 			onclick={resetTimer}
 		>
 			<i class="fas fa-rotate-left"></i>
-			<span class="kbd text-base-content">
-				{#if type === 'COMMENT_LIST'}
-					⌥ ⇧ R
-				{:else if type === 'SPEAKERS_LIST'}
-					⌥ R
-				{/if}
-			</span>
+			{#if type === 'COMMENT_LIST'}
+				<Kbd hotkey="alt+shift+R" class="text-base-content" />
+			{:else if type === 'SPEAKERS_LIST'}
+				<Kbd hotkey="alt+R" class="text-base-content" />
+			{/if}
 		</button>
 		<button
 			class="btn btn-lg join-item flex gap-2

--- a/src/lib/components/voting/RollCallVotingChair.svelte
+++ b/src/lib/components/voting/RollCallVotingChair.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { CommitteeTeamQuery$result } from '$houdini';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import Modal from '../Modal.svelte';
 	import hotkeys from 'hotkeys-js';
@@ -238,7 +239,7 @@
 				>
 					<i class="fas fa-circle-minus"></i>
 					{m.con()}
-					<span class="kbd">J</span>
+					<Kbd hotkey="J" />
 				</button>
 				{#if withAbstentions}
 					<button
@@ -249,7 +250,7 @@
 					>
 						<i class="fas fa-circle"></i>
 						{m.abstain()}
-						<span class="kbd">K</span>
+						<Kbd hotkey="K" />
 					</button>
 				{/if}
 				<button
@@ -260,7 +261,7 @@
 				>
 					<i class="fas fa-circle-plus"></i>
 					{m.pro()}
-					<span class="kbd">L</span>
+					<Kbd hotkey="L" />
 				</button>
 			</div>
 		</div>
@@ -274,7 +275,7 @@
 			>
 				<i class="fas fa-xmark"></i>
 				{m.close()}
-				<span class="kbd">esc</span>
+				<Kbd hotkey="esc" />
 			</button>
 		</div>
 	{/if}

--- a/src/lib/components/voting/ShowOfHandsVotingChair.svelte
+++ b/src/lib/components/voting/ShowOfHandsVotingChair.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { CommitteeTeamQuery$result } from '$houdini';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { onMount } from 'svelte';
 	import Modal from '../Modal.svelte';
@@ -183,7 +184,7 @@
 		<button class="btn btn-lg flex gap-2" onclick={previousState} disabled={currentState === 'PRO'}>
 			<i class="fas fa-arrow-left"></i>
 			{m.back()}
-			<span class="kbd">⌫</span>
+			<Kbd hotkey="backspace" />
 		</button>
 		<button
 			class="btn {currentState === 'EVALUATION' ? 'btn-error' : 'btn-success'} btn-lg flex gap-2"
@@ -201,7 +202,7 @@
 				<i class="fas fa-arrow-right"></i>
 				{m.forward()}
 			{/if}
-			<span class="kbd">↵</span>
+			<Kbd hotkey="enter" />
 		</button>
 
 		<div class="absolute top-3 right-3">

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/ChairNavbar.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/ChairNavbar.svelte
@@ -20,28 +20,28 @@
 			faIcon: 'fa-gears',
 			label: m.setup(),
 			href: './setup',
-			shortcut: '⌥ 1',
+			shortcut: 'alt+1',
 			active: page.route.id?.endsWith('setup')
 		},
 		{
 			faIcon: 'fa-users',
 			label: m.presence(),
 			href: './presence',
-			shortcut: '⌥ 2',
+			shortcut: 'alt+2',
 			active: page.route.id?.endsWith('presence')
 		},
 		{
 			faIcon: 'fa-podium',
 			label: m.speakersList(),
 			href: './speakers-list',
-			shortcut: '⌥ 3',
+			shortcut: 'alt+3',
 			active: page.route.id?.endsWith('speakers-list')
 		},
 		{
 			faIcon: 'fa-box-ballot',
 			label: m.voting(),
 			href: './voting',
-			shortcut: '⌥ 4',
+			shortcut: 'alt+4',
 			active: page.route.id?.endsWith('voting')
 		}
 	]);

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/setup/+page.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/setup/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
 	import type { PageData } from './$houdini';
+	import Kbd from '$lib/components/Kbd.svelte';
 	import IconInfoBox from '$lib/components/IconInfoBox.svelte';
 	import { getCommitteeStatusIcon, getCommitteeStatusText } from '$lib/utils/committeeStatus';
 	import UndrawError from '$lib/components/UndrawError.svelte';
@@ -72,7 +73,7 @@
 				</BasicCard>
 			</div>
 			<div class="flex h-full w-full flex-3 flex-col gap-4">
-				<BasicCard title={m.setStatus()} kbd="⌥ S">
+				<BasicCard title={m.setStatus()} kbd="alt+S">
 					<StatusChanger
 						committeeId={committee.id}
 						oldStatus={committee.status}
@@ -81,7 +82,7 @@
 						hasModeratedCaucus={committee.conference?.hasModeratedCaucus}
 					/>
 				</BasicCard>
-				<BasicCard title={m.stateOfDebate()} kbd="⌥ D">
+				<BasicCard title={m.stateOfDebate()} kbd="alt+D">
 					<StateOfDebate committeeId={committee.id} oldStateOfDebate={committee.stateOfDebate} />
 				</BasicCard>
 				<BasicCard title={m.agendaItem()}>
@@ -95,7 +96,7 @@
 					<a href="." class="btn btn-primary btn-lg mb-4 flex items-center gap-3" target="_blank">
 						<i class="fas fa-projector"></i>
 						{m.openPresentation()}
-						<span class="kbd text-base-content">⌥ P</span>
+						<Kbd hotkey="alt+P" class="text-base-content" />
 					</a>
 					<PresentationSettings committeeId={data.committeeId} />
 				</BasicCard>


### PR DESCRIPTION
## Summary
- Adds a new `Kbd.svelte` component that detects the user's OS and renders Mac symbols (⌥, ⇧, ⌘, etc.) or text labels (Alt, Shift, Ctrl, etc.) accordingly
- Replaces all hardcoded Mac-style Unicode keyboard shortcut displays across 12 files with the new `Kbd` component
- Non-Mac users now see familiar key names (e.g. `Alt+1`) instead of unfamiliar Mac symbols (e.g. `⌥1`)

## Test plan
- [ ] On Mac: verify keyboard shortcuts render with Mac symbols (⌥, ⇧, ⌘, ␣, ⌫, ↵)
- [ ] On Windows/Linux (or spoofed user agent): verify text labels render (Alt, Shift, Ctrl, etc.) joined with `+`
- [ ] Verify all hotkey displays render correctly in: ChairNavbar, setup page, speakers list controls, voting modals, roll call, and alert dialogs
- [ ] Verify `kbd-sm` size variant works correctly in PromiseAlert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated keyboard shortcut display logic into a unified component for consistent formatting across the app.

* **Style**
  * Improved keyboard hint rendering with platform-specific symbols (macOS) and standardized notation (e.g., "alt+A" instead of "⌥ A") for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->