### PR TITLE
feat: add tooltips to status changer tabs and time icons

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -148,6 +148,8 @@
 	"memberAdded": "Mitglied erfolgreich hinzugefügt",
 	"memberRemoved": "Mitglied erfolgreich entfernt",
 	"memberUpdated": "Mitglied erfolgreich aktualisiert",
+	"minuteOfTheHour": "Absolute Zeit: Springe zur entsprechenden Minute dieser oder der nächsten Stunde",
+	"minutesFromNow": "Relative Zeit: Springe X Minuten in die Zukunft",
 	"missionControl": "Mission Control",
 	"moderatedInformalCaucus": "Moderierte informelle Sitzung",
 	"nextSpeaker": "Nächste Rede",

--- a/messages/en.json
+++ b/messages/en.json
@@ -148,6 +148,8 @@
 	"memberAdded": "Member added successfully",
 	"memberRemoved": "Member removed successfully",
 	"memberUpdated": "Member updated successfully",
+	"minuteOfTheHour": "Absolute time: Jump to the corresponding minute of this or the next hour",
+	"minutesFromNow": "Relative time: Jump X minutes into the future",
 	"missionControl": "Mission Control",
 	"moderatedInformalCaucus": "Moderated informal caucus",
 	"nextSpeaker": "Next Speech",

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -3,6 +3,7 @@
 		id: T;
 		faIcon?: string;
 		label?: string;
+		tooltip?: string;
 	};
 
 	interface Props {
@@ -18,7 +19,10 @@
 	{#each tabs as tab}
 		<button
 			role="tab"
-			class="tab flex-1 {activeTab === tab.id ? 'tab-active' : ''} h-auto items-center py-3"
+			class="tab flex-1 {activeTab === tab.id
+				? 'tab-active'
+				: ''} h-auto items-center py-3 tooltip tooltip-bottom"
+			data-tip={tab.tooltip}
 			aria-selected={activeTab === tab.id}
 			aria-label={tab.label ?? tab.faIcon}
 			tabindex={activeTab === tab.id ? 0 : -1}

--- a/src/lib/components/committee/StatusChanger.svelte
+++ b/src/lib/components/committee/StatusChanger.svelte
@@ -27,16 +27,18 @@
 	const categories: {
 		id: CommitteeStatusEnum$options;
 		faIcon: string;
+		tooltip: string;
 	}[] = [
-		{ id: 'FORMAL', faIcon: 'podium' },
-		{ id: 'INFORMAL', faIcon: 'messages' },
-		{ id: 'PAUSE', faIcon: 'mug-saucer' },
-		{ id: 'SUSPENSION', faIcon: 'forward-step' },
+		{ id: 'FORMAL', faIcon: 'podium', tooltip: m.formalDebate() },
+		{ id: 'INFORMAL', faIcon: 'messages', tooltip: m.informalCaucus() },
+		{ id: 'PAUSE', faIcon: 'mug-saucer', tooltip: m.pause() },
+		{ id: 'SUSPENSION', faIcon: 'forward-step', tooltip: m.suspension() },
 		...(hasModeratedCaucus
 			? [
 					{
 						id: 'MODERATED_INFORMAL' as CommitteeStatusEnum$options,
-						faIcon: 'comments-question-check'
+						faIcon: 'comments-question-check',
+						tooltip: m.moderatedInformalCaucus()
 					}
 				]
 			: [])
@@ -108,7 +110,9 @@
 <div class="flex flex-col gap-4">
 	<Tabs tabs={categories} bind:activeTab={activeCategory} />
 	<div class="card bg-base-200 flex flex-row items-center gap-2 p-2">
-		<i class="fa-duotone fa-clock w-8 text-center text-2xl"></i>
+		<div class="tooltip tooltip-right flex items-center" data-tip={m.minuteOfTheHour()}>
+			<i class="fa-duotone fa-clock w-8 text-center text-2xl"></i>
+		</div>
 		<div
 			class="grid flex-1 grid-cols-4 items-center gap-1 md:grid-cols-5 lg:grid-cols-8 xl:grid-cols-12"
 		>
@@ -126,7 +130,9 @@
 		</div>
 	</div>
 	<div class="card bg-base-200 flex flex-row items-center gap-2 p-2">
-		<i class="fa-duotone fa-timer w-8 text-center text-2xl"></i>
+		<div class="tooltip tooltip-right flex items-center" data-tip={m.minutesFromNow()}>
+			<i class="fa-duotone fa-timer w-8 text-center text-2xl"></i>
+		</div>
 		<div class="grid flex-1 grid-cols-4 items-center gap-1 md:grid-cols-5 lg:grid-cols-7">
 			{#each relativeTimes as time}
 				<button


### PR DESCRIPTION
## Summary
- Add tooltips to status category tabs (Formal, Informal, Pause, Suspension, Moderated Informal) in the StatusChanger component
- Add tooltip support to the generic `Tabs.svelte` component via a new `tooltip` property
- Add tooltips to the clock/timer icons explaining "absolute time" vs "relative time" behavior
- Add i18n messages for the new tooltip strings in both German and English

## Test plan
- [ ] Hover over status tabs (formal, informal, pause, suspension, moderated informal) and verify tooltips appear with correct labels
- [ ] Hover over the clock icon and verify "Absolute time" tooltip appears
- [ ] Hover over the timer icon and verify "Relative time" tooltip appears
- [ ] Verify tooltips render in both German and English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tooltip functionality to tab components and status categories
  * Enhanced time-related UI elements with helpful tooltips
  * Added new localization strings for time-based messaging in English and German

<!-- end of auto-generated comment: release notes by coderabbit.ai -->