### PR TITLE
chore: Add German resolution preamble and operative phrases

### DIFF
--- a/src/lib/utils/resolutionPhrases.ts
+++ b/src/lib/utils/resolutionPhrases.ts
@@ -1,0 +1,44 @@
+import { browser } from '$app/environment';
+
+interface PhraseLists {
+	preamble: string[];
+	operative: string[];
+}
+
+let cached: PhraseLists | undefined;
+let pending: Promise<PhraseLists> | undefined;
+
+function parse(content: string): string[] {
+	return content
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line && !line.startsWith('#'));
+}
+
+export async function loadResolutionPhrases(fetchFn: typeof fetch = fetch): Promise<PhraseLists> {
+	if (cached) return cached;
+	if (pending) return pending;
+
+	pending = (async () => {
+		const [preambleRes, operativeRes] = await Promise.all([
+			fetchFn('/resolution-phrases/preamble.txt'),
+			fetchFn('/resolution-phrases/operative.txt')
+		]);
+		const [preambleText, operativeText] = await Promise.all([
+			preambleRes.text(),
+			operativeRes.text()
+		]);
+		const result: PhraseLists = {
+			preamble: parse(preambleText),
+			operative: parse(operativeText)
+		};
+		if (browser) cached = result;
+		return result;
+	})();
+
+	try {
+		return await pending;
+	} finally {
+		pending = undefined;
+	}
+}

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/resolutions/[paperId]/+page.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/resolutions/[paperId]/+page.svelte
@@ -31,6 +31,7 @@
 	import toast from 'svelte-french-toast';
 	import { openVotingModal } from '$lib/components/voting/votingModal';
 	import { getResolutionLabels } from '$lib/utils/resolutionEditorLabels';
+	import { loadResolutionPhrases } from '$lib/utils/resolutionPhrases';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	import { getCurrentUser } from '$lib/state/currentUser.svelte';
@@ -369,6 +370,14 @@
 		return () => {
 			window.removeEventListener('scroll', handleScroll);
 		};
+	});
+
+	let preamblePhrases = $state<string[]>([]);
+	let operativePhrases = $state<string[]>([]);
+	onMount(async () => {
+		const phrases = await loadResolutionPhrases();
+		preamblePhrases = phrases.preamble;
+		operativePhrases = phrases.operative;
 	});
 
 	// Save status — kept for future use (e.g. title or metadata mutations); content auto-syncs via Y.js
@@ -1405,6 +1414,8 @@
 					presence={presence ?? undefined}
 					{headerData}
 					labels={getResolutionLabels()}
+					{preamblePhrases}
+					{operativePhrases}
 					editable={canEdit && editorMode === 'edit'}
 					amendments={paper.status === 'AMENDMENT_PHASE' ? amendmentOverlays : undefined}
 					rejectedClauseIds={paper.status === 'VOTING_PHASE' || paper.status === 'FINAL'

--- a/src/routes/app/[conferenceId]/participant/[committeeId]/papers/[paperId]/+page.svelte
+++ b/src/routes/app/[conferenceId]/participant/[committeeId]/papers/[paperId]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
@@ -29,6 +29,7 @@
 	import { getTranslatedCountryNameFromAlpha3Code } from '$lib/utils/nationTranslationHelper.svelte';
 	import toast from 'svelte-french-toast';
 	import { getResolutionLabels } from '$lib/utils/resolutionEditorLabels';
+	import { loadResolutionPhrases } from '$lib/utils/resolutionPhrases';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	const currentUser = await getCurrentUser();
@@ -267,6 +268,14 @@
 	let wsSynced = $state(false);
 	let wsConnected = $state(false);
 	let wsForbidden = $state(false);
+
+	let preamblePhrases = $state<string[]>([]);
+	let operativePhrases = $state<string[]>([]);
+	onMount(async () => {
+		const phrases = await loadResolutionPhrases();
+		preamblePhrases = phrases.preamble;
+		operativePhrases = phrases.operative;
+	});
 
 	$effect(() => {
 		const paperId = page.params.paperId;
@@ -1009,6 +1018,8 @@
 					presence={presence ?? undefined}
 					{headerData}
 					labels={getResolutionLabels()}
+					{preamblePhrases}
+					{operativePhrases}
 					editable={canEdit && paper.status !== 'VOTING_PHASE' && paper.status !== 'FINAL'}
 					amendments={showAmendmentUI ? amendmentOverlays : undefined}
 					rejectedClauseIds={paper.status === 'VOTING_PHASE' || paper.status === 'FINAL'

--- a/static/resolution-phrases/operative.txt
+++ b/static/resolution-phrases/operative.txt
@@ -1,0 +1,87 @@
+akzeptiert
+appelliert eindringlich
+appelliert
+autorisiert
+beauftragt
+bedauert
+bedenkt
+befürwortet
+begrüßt wärmstens
+begrüßt
+behält sich vor
+behält sich
+beklagt
+bekräftigt
+bekundet
+bekundet hocherfreut
+bemerkt
+beschließt
+bestätigt
+betont
+betrachtet
+billigt
+bittet
+dankt
+drängt
+empfiehlt dringend
+empfiehlt
+entschließt sich
+entsendet
+erinnert
+erkennt an
+erklärt
+erklärt erneut
+ernennt
+ermutigt
+ersucht
+erwägt
+fordert
+gratuliert
+hebt hervor
+hofft
+ist sich bewusst
+ist überzeugt
+ist fest überzeugt
+kommt überein
+kommt zu dem Schluss
+kommt zu der Überzeugung
+legt dringend nahe
+legt nahe
+lenkt auf
+lenkt die Aufmerksamkeit auf
+lobt
+lobt feierlich
+macht sich zu eigen
+nimmt an
+nimmt hocherfreut zur Kenntnis
+nimmt zur Kenntnis
+nimmt mit Bedauern zur Kenntnis
+räumt ein
+ruft
+ruft abermals
+schlägt vor
+schließt sich
+setzt
+setzt ein
+setzt von neuem
+setzt von neuem ein
+stellt fest
+unterstreicht
+unterstützt
+verabschiedet
+verlangt
+verlangt unmissverständlich
+vermerkt
+verpflichtet sich
+verschärft
+versichert
+verurteilt
+verurteilt entschieden
+verweist
+wiederholt
+weist auf hin
+weist auf die Tatsache hin
+würdigt
+zieht in Erwägung
+zieht ernsthaft in Erwägung
+zieht ernsthaft in Erwägung

--- a/static/resolution-phrases/preamble.txt
+++ b/static/resolution-phrases/preamble.txt
@@ -1,0 +1,88 @@
+alarmiert
+anerkennend
+bedauernd
+zutiefst bedauernd
+begrüßend
+bekräftigend
+erneut bekräftigend
+bemerkend
+beobachtend
+besorgt
+höchst besorgt
+bestätigend
+bestürzt
+tief bestürzt
+betonend
+beunruhigt
+der Hoffnung Ausdruck gebend
+eingedenk
+entschlossen
+tief entschlossen
+enttäuscht
+erfreut
+erinnernd
+erklärend
+erneut erklärend
+ermutigend
+feststellend
+von neuem feststellend
+geleitet von
+gestützt auf
+hervorhebend
+hinweisend auf
+im Bewusstsein
+im vollen Bewusstsein
+im Glauben
+im festen Glauben
+im Hinblick auf
+in Anbetracht
+in Anbetracht der Tatsache
+in Anerkennung
+in Anerkennung der Notwendigkeit
+in Bekräftigung
+in Betracht ziehend
+in der Absicht
+in Erinnerung
+in Erinnerung an
+in Erkenntnis
+in Erwartung
+in Kenntnis
+in tiefer Sorge
+in Sorge
+missbilligend
+mit dem Ausdruck der Anerkennung
+mit dem Ausdruck des Bedauerns
+mit dem Ausdruck der Besorgnis
+mit dem Ausdruck der tiefen Besorgnis
+mit dem Ausdruck des Dankes
+mit dem Ausdruck der Entschlossenheit
+mit dem Ausdruck der Unterstützung
+mit dem Ausdruck der Wertschätzung
+mit dem Wunsch
+mit einbeziehend
+mit Enttäuschung zur Kenntnis nehmend
+mit Interesse zur Kenntnis nehmend
+mit Sorge zur Kenntnis nehmend
+mit tiefer Sorge zur Kenntnis nehmend
+nach Behandlung
+nach Prüfung
+nach Untersuchung
+tätig werdend
+unter Begrüßung
+unter Berücksichtigung
+unter Hervorhebung
+unter Hinweis auf
+unter Kenntnisnahme
+unter Missbilligung
+unter Verurteilung
+unter Zustimmung
+unterstützend
+fest überzeugt
+überzeugt
+verlangend
+verurteilend
+entschieden verurteilend
+würdigend
+zu der Erkenntnis kommend
+zur Kenntnis nehmend
+zuversichtlich


### PR DESCRIPTION
## Summary

Add comprehensive lists of German-language resolution phrases used in Model United Nations proceedings. These phrase lists serve as reference data for the resolution editing functionality.

## Changes

- **`static/resolution-phrases/preamble.txt`**: Added 88 German preamble phrases (e.g., "alarmiert", "anerkennend", "bedauernd") used to introduce resolution context and express positions
- **`static/resolution-phrases/operative.txt`**: Added 87 German operative phrases (e.g., "akzeptiert", "appelliert", "beauftragt") used in the operative clauses of resolutions

These phrase lists provide standardized UN resolution language in German, supporting the resolution editing and drafting features of the MUNify CHASE application.

https://claude.ai/code/session_01U7za34Fa51QDH1mvoFFioQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resolution editors now have access to predefined phrase suggestions for both preamble and operative sections to streamline resolution composition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/345)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->