### PR TITLE
fix(graphql): raise query depth limit beyond armor's default of 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "@inlang/cli": "^3.1.10",
         "@inlang/paraglide-js": "^2.17.0",
         "@lingual/i18n-check": "^0.9.4",
-        "@m1212e/rumble": "^0.17.3",
+        "@m1212e/rumble": "^0.18.1",
         "@m1212e/sveltekit-oidc": "^0.0.39",
         "@m1212e/urql-exchange-graphcache": "9.0.1",
         "@pothos/plugin-validation": "^4.2.0",
@@ -361,7 +361,7 @@
 
     "@lix-js/server-protocol-schema": ["@lix-js/server-protocol-schema@0.1.1", "", {}, "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ=="],
 
-    "@m1212e/rumble": ["@m1212e/rumble@0.17.3", "", { "dependencies": { "@escape.tech/graphql-armor": "^3.2.0", "@graphql-yoga/plugin-disable-introspection": "^2.22.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@pothos/core": "^4.12.0", "@pothos/plugin-drizzle": "^0.17.3", "@pothos/plugin-smart-subscriptions": "^4.1.4", "@pothos/plugin-tracing": "^1.1.2", "@pothos/tracing-opentelemetry": "^1.1.3", "@urql/core": "^6.0.1", "@urql/exchange-graphcache": "^9.0.0", "@urql/introspection": "^1.2.1", "devalue": "^5.7.1", "es-toolkit": "^1.46.0", "graphql-scalars": "^1.25.0", "graphql-yoga": "^5.21.0", "pluralize": "^8.0.0", "wonka": "6.3.2" }, "peerDependencies": { "drizzle-orm": "^1", "graphql": "^16", "graphql-ws": "^6", "sofa-api": "^0.18", "svelte": "^5", "typescript": "^4 || ^5 || ^6" }, "optionalPeers": ["graphql-ws", "sofa-api", "svelte"] }, "sha512-DUyotguymQOLz3XH8z9H3d4nzedsKUqHxVM0x2ON27XnQn58rm89QmPyUGMLpUR1Sj7gKenOdDwXmvpByF8Iww=="],
+    "@m1212e/rumble": ["@m1212e/rumble@0.18.1", "", { "dependencies": { "@escape.tech/graphql-armor": "^3.2.0", "@graphql-yoga/plugin-disable-introspection": "^2.22.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@pothos/core": "^4.12.0", "@pothos/plugin-drizzle": "^0.17.3", "@pothos/plugin-smart-subscriptions": "^4.1.4", "@pothos/plugin-tracing": "^1.1.2", "@pothos/tracing-opentelemetry": "^1.1.3", "@urql/core": "^6.0.1", "@urql/exchange-graphcache": "^9.0.0", "@urql/introspection": "^1.2.1", "devalue": "^5.8.1", "es-toolkit": "^1.46.0", "graphql-scalars": "^1.25.0", "graphql-yoga": "^5.21.0", "pluralize": "^8.0.0", "wonka": "6.3.2" }, "peerDependencies": { "drizzle-orm": "^1", "graphql": "^16", "graphql-ws": "^6", "sofa-api": "^0.18", "svelte": "^5", "typescript": "^4 || ^5 || ^6" }, "optionalPeers": ["graphql-ws", "sofa-api", "svelte"] }, "sha512-c9f9OPly8Ayqm7AH+zn9rDFDU/Gk6x6JuIXX5waH3Dp4BohTOdX+ztxcYXdpz+ICNzkC7xQfAXlrkottlZFumQ=="],
 
     "@m1212e/sveltekit-oidc": ["@m1212e/sveltekit-oidc@0.0.39", "", { "dependencies": { "jose": "^6.2.2", "openid-client": "^6.8.2", "typebox": "^1.1.22" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-9dsrGPbGQPQJot8J+1RfsWMTzY36Z4u9Htnr/nnFZiTx16ivbylyLlq+weXDQmZ165WhXOPETBMP/wzg484r7A=="],
 
@@ -877,7 +877,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "dexie": ["dexie@4.4.2", "", {}, "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw=="],
 
@@ -1729,6 +1729,8 @@
 
     "@sveltejs/kit/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
+    "@sveltejs/kit/devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -1782,6 +1784,8 @@
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "sirv/@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "svelte/devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
 
     "svelte-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@inlang/cli": "^3.1.10",
 		"@inlang/paraglide-js": "^2.17.0",
 		"@lingual/i18n-check": "^0.9.4",
-		"@m1212e/rumble": "^0.17.3",
+		"@m1212e/rumble": "^0.18.1",
 		"@m1212e/sveltekit-oidc": "^0.0.39",
 		"@pothos/plugin-validation": "^4.2.0",
 		"@sveltejs/adapter-node": "^5.5.4",

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -67,7 +67,10 @@ async function authenticateWebSocketRequest(req: IncomingMessage) {
 	return syntheticEvent.locals;
 }
 
-createWs(useServer, {}, gqlWSS);
+// rumble 0.18.1's createWs over-constrains the `implementation` generic so that
+// graphql-ws's `useServer` (which keeps its own generic parameters) no longer
+// satisfies it. Runtime is unaffected — strip the generics at the call boundary.
+createWs(useServer as unknown as (options: unknown, ws: typeof gqlWSS) => void, {}, gqlWSS);
 
 type LocalsBag = RequestEvent['locals'];
 type RequestWithLocals = IncomingMessage & { locals?: LocalsBag };

--- a/src/routes/api/graphql/+server.ts
+++ b/src/routes/api/graphql/+server.ts
@@ -4,6 +4,12 @@ import '$api/handlers/register';
 
 const yogaInstance = createYoga({
 	graphqlEndpoint: '/api/graphql',
+	// The deepest query in this app reaches depth 7
+	// (committee → activeAgendaItem → speakersList → speakers → committeeMember → representation → name).
+	// Raise armor's default of 6 to 10 so legitimate queries pass while still rejecting absurd ones.
+	armorConfig: {
+		maxDepth: { n: 10 }
+	},
 	fetchAPI: {
 		fetch,
 		Request,


### PR DESCRIPTION
## Summary

- Production users saw `CombinedError: [GraphQL] Syntax Error: Query depth limit of 6 exceeded, found 7` on multiple pages (chairs layout, presentation, speakers-list, participant committee). Locally everyone was fine.
- Cause: Rumble auto-installs `EnvelopArmorPlugin` in production with graphql-armor's defaults (`maxDepth.n = 6`). Locally `NODE_ENV === "development"` skips the plugin entirely, masking the issue. The deepest query in the app is depth **7**: `committee → activeAgendaItem → speakersList → speakers → committeeMember → representation → name`.
- Fix: bump `@m1212e/rumble` to `^0.18.1` (which adds an `armorConfig` pass-through that landed upstream specifically for this) and configure `maxDepth.n = 10` in `createYoga`. ~40% headroom over current usage; other armor defaults (aliases, directives, tokens) were not being tripped and are left untouched.
- Side fix: rumble 0.18.1's new `createWs` signature over-constrains the `implementation` generic, so `graphql-ws`'s `useServer` no longer satisfies it. Cast at the call boundary; runtime is unchanged.

## Depth survey

| Depth | Location | Path |
| ----- | -------- | ---- |
| **7** | `(chairs)/+layout.svelte`, `(presentation)/+page.svelte`, `(chairs)/speakers-list/+page.svelte`, `participant/[committeeId]/+page.svelte` | `committee → activeAgendaItem → speakersList → speakers → committeeMember → representation → name` |
| 5 | resolution-paper / comments / amendments / mission-control config | `*.sponsors.committeeMember.representation.<scalar>` etc. |
| ≤ 4 | everything else | — |

Mutations max out at depth 3.

## Test plan

- [ ] `bun run typecheck` passes (verified locally)
- [ ] `bun run dev` starts cleanly
- [ ] Pages that previously failed (`/app/[conferenceId]/[committeeId]` chair speakers-list, presentation view, participant committee view) load without GraphQL depth errors on a production-style build (`bun run build && bun run preview`)
- [ ] Spot-check that introspection is still disabled in prod (GraphiQL not reachable at `/api/graphql`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency to latest version.

* **Bug Fixes**
  * Increased GraphQL query depth limit to support more complex queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->