### PR TITLE
fix: Replace SvelteSet with array in AddCountriesModal

### DIFF
--- a/src/lib/components/AddCountriesModal.svelte
+++ b/src/lib/components/AddCountriesModal.svelte
@@ -44,13 +44,13 @@
 
 		const countries: ParsedCountry[] = [];
 		const unrecognized: string[] = [];
-		const addedCodes = new Set<string>();
+		const addedCodes: string[] = [];
 
 		for (const token of tokens) {
 			const normalized = token.toLowerCase();
 
 			// Skip if we've already added this country
-			if (addedCodes.has(normalized)) {
+			if (addedCodes.includes(normalized)) {
 				continue;
 			}
 
@@ -71,8 +71,8 @@
 					alpha3Code: country.cca3.toLowerCase(),
 					name: country.name.common
 				});
-				addedCodes.add(country.cca2.toLowerCase());
-				addedCodes.add(country.cca3.toLowerCase());
+				addedCodes.push(country.cca2.toLowerCase());
+				addedCodes.push(country.cca3.toLowerCase());
 			} else if (token.length >= 2 && token.length <= 3) {
 				// Only mark as unrecognized if it looks like a country code (2-3 chars)
 				unrecognized.push(token.toUpperCase());

--- a/src/lib/components/AddCountriesModal.svelte
+++ b/src/lib/components/AddCountriesModal.svelte
@@ -3,7 +3,6 @@
 	import Modal from './Modal.svelte';
 	import CountryBadge from './CountryBadge.svelte';
 	import WorldCountries from 'world-countries';
-	import { SvelteSet } from 'svelte/reactivity';
 
 	interface ParsedCountry {
 		alpha2Code: string;
@@ -45,7 +44,7 @@
 
 		const countries: ParsedCountry[] = [];
 		const unrecognized: string[] = [];
-		const addedCodes = new SvelteSet<string>();
+		const addedCodes = new Set<string>();
 
 		for (const token of tokens) {
 			const normalized = token.toLowerCase();


### PR DESCRIPTION
## Summary

Replaced `SvelteSet` with a standard JavaScript array for tracking added country codes in the `AddCountriesModal` component. This simplifies the implementation while maintaining the same deduplication functionality.

## Changes

- Removed `SvelteSet` import from `svelte/reactivity`
- Changed `addedCodes` from `new SvelteSet<string>()` to `[]` (standard array)
- Updated deduplication check from `addedCodes.has(normalized)` to `addedCodes.includes(normalized)`
- Updated code additions from `addedCodes.add()` to `addedCodes.push()`

## Implementation Details

The change maintains the same behavior for preventing duplicate country entries during parsing. Since the `addedCodes` collection is local to the parsing function and doesn't require reactive updates, a standard array is more appropriate than a `SvelteSet`. The `includes()` method provides adequate performance for the expected number of countries being added in a single modal interaction.

https://claude.ai/code/session_0144qSiQW3i4fbVHvk7Yxncg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data tracking in the countries modal component.

---

**Note:** This release includes internal code improvements with no visible changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->