### PR TITLE
fix: Implement conference deletion with pubsub notification

### DIFF
--- a/src/api/handlers/conference.ts
+++ b/src/api/handlers/conference.ts
@@ -136,6 +136,8 @@ schemaBuilder.mutationFields((t) => ({
 					ctx.abilities.conference.filter('delete').merge({ where: { id: args.id } }).sql.where
 				);
 
+			pubsub.removed();
+
 			return true;
 		}
 	})

--- a/src/lib/components/DeleteConferenceModal.svelte
+++ b/src/lib/components/DeleteConferenceModal.svelte
@@ -2,6 +2,8 @@
 	import { m } from '$lib/paraglide/messages';
 	import Modal from './Modal.svelte';
 	import toast from 'svelte-french-toast';
+	import { client } from '$lib/api/rumbleClient/client';
+	import { promiseToastStrings } from '$lib/utils/toast';
 
 	interface Props {
 		open: boolean;
@@ -9,7 +11,6 @@
 		conferenceName: string;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	let { open = $bindable(), conferenceId, conferenceName }: Props = $props();
 
 	let confirmInput = $state('');
@@ -21,8 +22,11 @@
 		if (!canDelete) return;
 		isDeleting = true;
 		try {
-			// TODO: deleteConference not available in Rumble client yet
-			toast.error('deleteConference is not yet available');
+			await toast.promise(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- rumble generator types delete mutations as plain `Boolean` instead of callable functions
+				(client.mutate.deleteConference as any)({ __args: { id: conferenceId } } as any),
+				promiseToastStrings(conferenceName, 'delete')
+			);
 			open = false;
 		} finally {
 			isDeleting = false;


### PR DESCRIPTION
## Summary
Implements the conference deletion feature by connecting the frontend delete modal to the GraphQL mutation and adding real-time pubsub notifications when a conference is deleted.

## Changes

### Frontend (`DeleteConferenceModal.svelte`)
- Replaced placeholder error toast with actual `deleteConference` mutation call
- Integrated with Rumble client to execute the delete mutation with conference ID
- Added promise-based toast feedback using `promiseToastStrings` utility for better UX
- Removed unused ESLint disable comment, added necessary one for Rumble's type generation quirks

### Backend (`conference.ts`)
- Added `pubsub.removed()` call in the `deleteConference` mutation to broadcast deletion events to subscribed clients
- Enables real-time updates across connected clients when a conference is deleted

## Implementation Details
- Uses type assertions (`as any`) to work around Rumble's type generation for delete mutations (which are typed as plain `Boolean` instead of callable functions)
- Leverages existing `promiseToastStrings` utility for consistent toast messaging across delete operations
- Pubsub notification allows other users viewing the conference list to see the deletion in real-time

https://claude.ai/code/session_01E5N9sTMbVQyogkH4Ppmfkw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conference deletion now triggers real-time updates across the application, ensuring all connected users receive immediate notifications when a conference is removed from the system
  * Enhanced deletion workflow with toast notifications providing users with clear, contextual feedback on deletion status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->