### PR TITLE
fix: 352 error on posting team only comment

### DIFF
--- a/src/api/handlers/resolutionComment.ts
+++ b/src/api/handlers/resolutionComment.ts
@@ -45,7 +45,7 @@ abilityBuilder.resolutionComment.allow('read').when((ctx) => {
 // Regular logged-in users → only see PUBLIC comments
 abilityBuilder.resolutionComment.allow('read').when((ctx) => {
 	ctx.mustBeLoggedIn();
-	return { where: { visibility: 'PUBLIC' } };
+	return true;
 });
 
 const ref = object({ table: 'resolutionComment' });
@@ -160,14 +160,10 @@ schemaBuilder.mutationFields((t) => ({
 			pubsub.created();
 			paperPubsub.updated(args.paperId);
 
+			// Return without ability filter: the comment was just validated and inserted by this user,
+			// no additional auth check needed on the return value.
 			return db.query.resolutionComment
-				.findFirst(
-					query(
-						ctx.abilities.resolutionComment.filter('read').merge({
-							where: { id: result.id }
-						}).query.single
-					)
-				)
+				.findFirst(query({ where: { id: result.id } }))
 				.then(assertFindFirstExists);
 		}
 	}),
@@ -206,14 +202,10 @@ schemaBuilder.mutationFields((t) => ({
 			pubsub.updated(args.commentId);
 			paperPubsub.updated(comment.paperId);
 
+			// Return without ability filter: the user just proved ownership above,
+			// no additional auth check needed on the return value.
 			return db.query.resolutionComment
-				.findFirst(
-					query(
-						ctx.abilities.resolutionComment.filter('read').merge({
-							where: { id: args.commentId }
-						}).query.single
-					)
-				)
+				.findFirst(query({ where: { id: args.commentId } }))
 				.then(assertFindFirstExists);
 		}
 	}),

--- a/src/lib/components/Flag.svelte
+++ b/src/lib/components/Flag.svelte
@@ -62,7 +62,7 @@
 		if (representation?.type === 'UN') return 'un';
 		if (representation?.alpha2Code) return representation.alpha2Code.toLowerCase();
 		if (representation?.alpha3Code)
-			return Alpha3.toAlpha2(representation.alpha3Code)?.toLowerCase();
+			return Alpha3.toAlpha2(representation.alpha3Code, true)?.toLowerCase();
 		return null;
 	});
 </script>


### PR DESCRIPTION
fixes #352

had a problem with src/api/handlers/resolutionComment.ts
I am not sure if my change to return true; in line 48 is correct. **please check**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolution comments are now accessible to all logged-in users with proper permissions handling.
  * Flag rendering improved through corrected country code normalization for accurate display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->