### PR TITLE
feat: more flexible and streamlined NSA user resolvement

### DIFF
--- a/src/api/handlers/nsaPresenceEvent.ts
+++ b/src/api/handlers/nsaPresenceEvent.ts
@@ -34,32 +34,28 @@ const pubsub = rumblePubsub({ table: 'nsaPresenceEvent' });
 query({ table: 'nsaPresenceEvent' });
 
 /**
- * Resolves the target NSA `conferenceUser` for a scan, given exactly one of
- * `conferenceUserId` (from QR) or `attendanceCode` (from manual fallback).
- * Scoped to the conference owning the target committee.
+ * Resolves the target NSA `conferenceUser` for a scan given a code
+ * that may be a conferenceUser.id (30-char nanoid), an attendanceCode (6-char),
+ * or a global user.id (OIDC subject). Scoped to the conference owning the target committee.
  */
 async function resolveNsaTarget(args: {
 	committee: typeof schema.committee.$inferSelect;
-	conferenceUserId?: string | null;
-	attendanceCode?: string | null;
+	code: string;
 }) {
-	const hasUserId = !!args.conferenceUserId;
-	const hasCode = !!args.attendanceCode;
-	if (hasUserId === hasCode) {
-		throw new GraphQLError('Provide exactly one of conferenceUserId or attendanceCode');
-	}
+	const code = args.code.trim();
+	if (!code) throw new GraphQLError('Missing code');
+	const normalizedCode = code.toUpperCase();
 
-	const normalizedCode = args.attendanceCode?.trim().toUpperCase();
-
-	const target = await db.query.conferenceUser.findFirst({
+	const matches = await db.query.conferenceUser.findMany({
 		where: {
 			conferenceId: args.committee.conferenceId,
 			conferenceUserType: 'NON_STATE_ACTOR',
-			...(hasUserId ? { id: args.conferenceUserId! } : { attendanceCode: normalizedCode! })
+			OR: [{ id: code }, { attendanceCode: normalizedCode }, { user: { id: code } }]
 		}
 	});
-	if (!target) throw new GraphQLError('NSA user not found for this conference');
-	return target;
+	if (matches.length === 0) throw new GraphQLError('NSA user not found for this conference');
+	if (matches.length > 1) throw new GraphQLError('Ambiguous code: matches multiple NSA users');
+	return matches[0];
 }
 
 /**
@@ -93,8 +89,7 @@ schemaBuilder.mutationFields((t) => ({
 		type: NsaPresenceEventRef,
 		args: {
 			committeeId: t.arg.id({ required: true }),
-			conferenceUserId: t.arg.id(),
-			attendanceCode: t.arg.string()
+			code: t.arg.string({ required: true })
 		},
 		resolve: async (q, _root, args, ctx) => {
 			const committee = await db.query.committee
@@ -108,8 +103,7 @@ schemaBuilder.mutationFields((t) => ({
 
 			const target = await resolveNsaTarget({
 				committee,
-				conferenceUserId: args.conferenceUserId,
-				attendanceCode: args.attendanceCode
+				code: args.code
 			});
 
 			const triggeredBy = await db.query.conferenceUser.findFirst({
@@ -187,8 +181,7 @@ schemaBuilder.mutationFields((t) => ({
 		type: NsaPresenceEventRef,
 		args: {
 			committeeId: t.arg.id({ required: true }),
-			conferenceUserId: t.arg.id(),
-			attendanceCode: t.arg.string()
+			code: t.arg.string({ required: true })
 		},
 		resolve: async (q, _root, args, ctx) => {
 			const committee = await db.query.committee
@@ -202,8 +195,7 @@ schemaBuilder.mutationFields((t) => ({
 
 			const target = await resolveNsaTarget({
 				committee,
-				conferenceUserId: args.conferenceUserId,
-				attendanceCode: args.attendanceCode
+				code: args.code
 			});
 
 			const triggeredBy = await db.query.conferenceUser.findFirst({

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/presence/NsaScannerDrawer.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/presence/NsaScannerDrawer.svelte
@@ -66,10 +66,7 @@
 	async function handleScan(rawText: string) {
 		const text = rawText.trim();
 		if (!text) return;
-		// Heuristic: short codes (≤8 chars, alphanumeric) are treated as the manual
-		// fallback `attendanceCode`; longer values as the full conferenceUser.id (nanoid 30).
-		const isShortCode = text.length <= 8;
-		await runMutation(isShortCode ? { attendanceCode: text } : { conferenceUserId: text }, text);
+		await runMutation(text);
 	}
 
 	async function handleManualSubmit(e: Event) {
@@ -77,17 +74,14 @@
 		const code = manualCode.trim();
 		if (!code) return;
 		manualCode = '';
-		await runMutation({ attendanceCode: code }, code);
+		await runMutation(code);
 	}
 
-	async function runMutation(
-		ident: { conferenceUserId?: string; attendanceCode?: string },
-		fallbackLabel: string
-	) {
+	async function runMutation(code: string) {
 		if (busy) return;
 		busy = true;
 
-		const args = { committeeId, ...ident };
+		const args = { committeeId, code };
 		try {
 			const event =
 				mode === 'IN'
@@ -127,7 +121,7 @@
 				event.conferenceUser?.name ??
 				event.conferenceUser?.conferenceMember?.representation?.name ??
 				event.conferenceUser?.userEmail ??
-				fallbackLabel;
+				code;
 
 			let message: string;
 			if (mode === 'IN') {
@@ -142,7 +136,7 @@
 			beep(true);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
-			pushLog({ ok: false, mode, label: fallbackLabel, message: msg });
+			pushLog({ ok: false, mode, label: code, message: msg });
 			beep(false);
 		} finally {
 			busy = false;


### PR DESCRIPTION
This pull request refactors the NSA presence event scanning and mutation flow to simplify and generalize how codes are handled. It replaces the previous logic, which differentiated between `conferenceUserId` and `attendanceCode`, with a single, unified `code` argument that can represent a conference user ID, attendance code, or global user ID. This change streamlines both the backend API and the frontend scanner logic, reducing ambiguity and improving maintainability.

**API and Backend Refactor:**

* The `resolveNsaTarget` function now takes a single `code` argument and attempts to match it against possible NSA user identifiers (`conferenceUser.id`, `attendanceCode`, or `user.id`). It returns an error if the code is missing, ambiguous, or not found.
* All relevant mutations now require a single `code` argument instead of separate `conferenceUserId` and `attendanceCode` fields. [[1]](diffhunk://#diff-3caa66e8c59ddf812452b9b7239a3dc49e7c552404d01e26e6b1336a69467c6bL96-R92) [[2]](diffhunk://#diff-3caa66e8c59ddf812452b9b7239a3dc49e7c552404d01e26e6b1336a69467c6bL111-R106) [[3]](diffhunk://#diff-3caa66e8c59ddf812452b9b7239a3dc49e7c552404d01e26e6b1336a69467c6bL190-R184) [[4]](diffhunk://#diff-3caa66e8c59ddf812452b9b7239a3dc49e7c552404d01e26e6b1336a69467c6bL205-R198)

**Frontend Scanner Simplification:**

* The scanner logic in `NsaScannerDrawer.svelte` now always passes a single `code` to the mutation, removing the previous heuristic that tried to guess the code type. ([src/routes/app/[conferenceId]/[committeeId]/(chairs)/presence/NsaScannerDrawer.svelteL69-R84](diffhunk://#diff-553f4aac71379d5c60b0373045e2e7986df6be5a02042e62940b7f68ed828c47L69-R84))
* The logging and labeling logic now consistently uses the provided code, simplifying user feedback and error handling. ([src/routes/app/[conferenceId]/[committeeId]/(chairs)/presence/NsaScannerDrawer.svelteL130-R124](diffhunk://#diff-553f4aac71379d5c60b0373045e2e7986df6be5a02042e62940b7f68ed828c47L130-R124), [src/routes/app/[conferenceId]/[committeeId]/(chairs)/presence/NsaScannerDrawer.svelteL145-R139](diffhunk://#diff-553f4aac71379d5c60b0373045e2e7986df6be5a02042e62940b7f68ed828c47L145-R139))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated NSA check-in/check-out to use a unified code parameter instead of separate identifier types.
  * Simplified the scanner interface to pass raw scanned codes directly.
  * Improved error detection for missing, ambiguous, or invalid codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->