### PR TITLE
feat: Add committee quick-access links to navbar burger menu

### DIFF
--- a/src/lib/components/NavbarBurgerMenu.svelte
+++ b/src/lib/components/NavbarBurgerMenu.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { fade, fly } from 'svelte/transition';
+	import { resolve } from '$app/paths';
 	import ThemeSwitcher from './ThemeSwitcher.svelte';
 	import LanguageSwitcher from './LanguageSwitcher.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import type { Snippet } from 'svelte';
+
+	interface CommitteeLink {
+		id: string;
+		abbreviation: string;
+		name: string;
+	}
 
 	interface Item {
 		key?: string;
@@ -23,6 +30,8 @@
 		conferenceTitle?: string | null;
 		signOutHref?: string;
 		dashboardHref?: string;
+		conferenceId?: string;
+		committees?: CommitteeLink[];
 	}
 
 	let {
@@ -34,8 +43,14 @@
 		roleBadgeClass = 'badge-ghost',
 		conferenceTitle,
 		signOutHref,
-		dashboardHref
+		dashboardHref,
+		conferenceId,
+		committees = []
 	}: Props = $props();
+
+	const sortedCommittees = $derived(
+		[...committees].sort((a, b) => a.abbreviation.localeCompare(b.abbreviation))
+	);
 
 	let menuVisible = $state(false);
 
@@ -124,6 +139,26 @@
 						</a>
 					</li>
 				{/each}
+			{/if}
+
+			{#if conferenceId && sortedCommittees.length > 0}
+				<li class="menu-title mt-2">{m.committees()}</li>
+				<li>
+					<div class="grid grid-cols-3 gap-1 p-0 hover:bg-transparent">
+						{#each sortedCommittees as committee (committee.id)}
+							<a
+								href={resolve('/app/[conferenceId]/[committeeId]/(chairs)/setup', {
+									conferenceId,
+									committeeId: committee.id
+								})}
+								class="btn btn-sm btn-soft truncate"
+								title={committee.name}
+							>
+								{committee.abbreviation}
+							</a>
+						{/each}
+					</div>
+				</li>
 			{/if}
 
 			{#if toolsSnippet}

--- a/src/lib/components/NavbarBurgerMenu.svelte
+++ b/src/lib/components/NavbarBurgerMenu.svelte
@@ -144,14 +144,14 @@
 			{#if conferenceId && sortedCommittees.length > 0}
 				<li class="menu-title mt-2">{m.committees()}</li>
 				<li>
-					<div class="grid grid-cols-3 gap-1 p-0 hover:bg-transparent">
+					<div class="flex flex-wrap gap-1 p-0 hover:bg-transparent justify-center">
 						{#each sortedCommittees as committee (committee.id)}
 							<a
 								href={resolve('/app/[conferenceId]/[committeeId]/(chairs)/setup', {
 									conferenceId,
 									committeeId: committee.id
 								})}
-								class="btn btn-sm btn-soft truncate"
+								class="btn btn-sm btn-soft"
 								title={committee.name}
 							>
 								{committee.abbreviation}
@@ -168,9 +168,7 @@
 
 			{#if dashboardHref}
 				{#if items.length > 0 || toolsSnippet}
-					<li>
-						<div class="divider my-1"></div>
-					</li>
+					<div class="divider my-2"></div>
 				{/if}
 				<li>
 					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- fixed app-level route -->

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/ChairNavbar.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/ChairNavbar.svelte
@@ -52,6 +52,16 @@
 
 	let role = $derived(conferenceUsers?.[0]?.conferenceUserType);
 
+	const conference = await client.liveQuery.conference({
+		__args: { id: page.params.conferenceId! },
+		id: true,
+		committees: {
+			id: true,
+			name: true,
+			abbreviation: true
+		}
+	});
+
 	let menubarItems = $derived(
 		buildConferenceNavItems({
 			role,
@@ -217,6 +227,8 @@
 			roleLabel={roleLabelFor(role)}
 			roleBadgeClass={roleBadgeClassFor(role)}
 			{conferenceTitle}
+			{conferenceId}
+			committees={role === 'ADMIN' || role === 'TEAM' ? (conference?.committees ?? []) : []}
 			dashboardHref="/app"
 			signOutHref="/logout"
 		/>

--- a/src/routes/app/[conferenceId]/attendance/+page.svelte
+++ b/src/routes/app/[conferenceId]/attendance/+page.svelte
@@ -25,9 +25,14 @@
 		currentUser.email ||
 		'';
 
-	const conferenceMeta = await client.query.conference({
+	const conferenceMeta = await client.liveQuery.conference({
 		__args: { id: conferenceId },
-		title: true
+		title: true,
+		committees: {
+			id: true,
+			name: true,
+			abbreviation: true
+		}
 	});
 
 	const conferenceUsers = await client.liveQuery.conferenceUsers({
@@ -87,6 +92,8 @@
 					roleLabel={roleLabelFor(role)}
 					roleBadgeClass={roleBadgeClassFor(role)}
 					conferenceTitle={conferenceMeta?.title}
+					{conferenceId}
+					committees={role === 'ADMIN' || role === 'TEAM' ? (conferenceMeta?.committees ?? []) : []}
 					dashboardHref="/app"
 					signOutHref="/logout"
 				/>

--- a/src/routes/app/[conferenceId]/mission-control/+page.svelte
+++ b/src/routes/app/[conferenceId]/mission-control/+page.svelte
@@ -86,6 +86,8 @@
 			roleLabel={roleLabelFor(role)}
 			roleBadgeClass={roleBadgeClassFor(role)}
 			conferenceTitle={conference?.title}
+			conferenceId={page.params.conferenceId}
+			committees={role === 'ADMIN' || role === 'TEAM' ? (conference?.committees ?? []) : []}
 			dashboardHref="/app"
 			signOutHref="/logout"
 		/>

--- a/src/routes/app/[conferenceId]/mission-control/config/+page.svelte
+++ b/src/routes/app/[conferenceId]/mission-control/config/+page.svelte
@@ -153,6 +153,8 @@
 			roleLabel={roleLabelFor(role)}
 			roleBadgeClass={roleBadgeClassFor(role)}
 			conferenceTitle={conference?.title}
+			conferenceId={page.params.conferenceId}
+			committees={role === 'ADMIN' || role === 'TEAM' ? (conference?.committees ?? []) : []}
 			dashboardHref="/app"
 			signOutHref="/logout"
 		/>


### PR DESCRIPTION
## Summary

Adds committee quick-access links to the navbar burger menu for ADMIN and TEAM users, allowing them to navigate directly to committee setup pages from any conference page.

## Key Changes

- **NavbarBurgerMenu component**:
  - Added `CommitteeLink` interface to type committee data
  - Added `conferenceId` and `committees` props to component interface
  - Implemented sorted committee display (alphabetically by abbreviation) in a 3-column grid layout
  - Committee links navigate to `/app/[conferenceId]/[committeeId]/(chairs)/setup` using `resolve()` from `$app/paths`
  - Links only display when `conferenceId` is present and committees list is non-empty

- **Data fetching updates**:
  - **ChairNavbar.svelte**: Added `liveQuery.conference()` call to fetch committee data (id, name, abbreviation)
  - **attendance/+page.svelte**: Changed `query.conference()` to `liveQuery.conference()` and added committee data fetching
  - **mission-control/+page.svelte**: Added committee data to existing conference query
  - **mission-control/config/+page.svelte**: Added committee data to existing conference query

- **Access control**: Committee links only passed to NavbarBurgerMenu when user role is ADMIN or TEAM

## Implementation Details

- Committees are sorted client-side using `$derived` to ensure consistent alphabetical ordering
- Uses DaisyUI `btn btn-sm btn-soft` styling with `truncate` for long committee names
- Committee abbreviations displayed as button text with full name in title attribute for tooltips
- Responsive 3-column grid layout for committee buttons

https://claude.ai/code/session_014d8HCAFbYyuQ6aLxDoqGAN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Committees" submenu to the main navigation menu for Admin and Team members, enabling quick access to committee management and setup features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->