### PR TITLE
fix: Replace email-based user identification with user IDs

### DIFF
--- a/src/api/services/authHelper.ts
+++ b/src/api/services/authHelper.ts
@@ -29,15 +29,11 @@ export function isGlobalAdmin(ctx: Context) {
  * @returns A filter object for the conference query. Injectable at e.g. committee level.
  */
 export function isChairInConference(ctx: Context) {
-	const user = ctx.mustBeLoggedIn();
 	if (isGlobalAdmin(ctx)) {
 		return {};
 	}
 
-	const userEmail = user.email;
-	if (!userEmail) {
-		throw new Error('User email is required to check committee chair or admin status');
-	}
+	const userId = ctx.mustBeLoggedIn().sub;
 
 	return {
 		conference: {
@@ -45,7 +41,7 @@ export function isChairInConference(ctx: Context) {
 				{
 					users: {
 						user: {
-							email: userEmail
+							id: userId
 						},
 						conferenceUserType: 'ADMIN' as const
 					}
@@ -53,7 +49,7 @@ export function isChairInConference(ctx: Context) {
 				{
 					users: {
 						user: {
-							email: userEmail
+							id: userId
 						},
 						conferenceUserType: 'TEAM' as const
 					}
@@ -97,16 +93,12 @@ export function isAdmin(ctx: Context) {
 		return {};
 	}
 
-	const user = ctx.mustBeLoggedIn();
-	const userEmail = user.email;
-	if (!userEmail) {
-		throw new Error('User email is required to check committee chair or admin status');
-	}
+	const userId = ctx.mustBeLoggedIn().sub;
 
 	return {
 		users: {
 			user: {
-				email: userEmail
+				id: userId
 			},
 			conferenceUserType: 'ADMIN' as const
 		}
@@ -119,16 +111,16 @@ export function isAdmin(ctx: Context) {
  * @returns A filter object for the conference query. Injectable at conference level.
  */
 export function isParticipant(ctx: Context) {
-	const user = ctx.mustBeLoggedIn();
-	const userEmail = user.email;
-	if (!userEmail) {
-		throw new Error('User email is required to check participant status');
+	if (isGlobalAdmin(ctx)) {
+		return {};
 	}
+
+	const userId = ctx.mustBeLoggedIn().sub;
 
 	return {
 		users: {
 			user: {
-				email: userEmail
+				id: userId
 			}
 		}
 	};


### PR DESCRIPTION
## Summary

Refactors authentication helper functions to use user IDs (`sub` claim) instead of email addresses for identifying users in database queries. This improves reliability and removes email validation requirements from permission checks.

## Key Changes

- **`isChairInConference()`**: Changed from filtering by `user.email` to `user.sub` (user ID) in conference admin/team member queries
- **`isAdmin()`**: Updated to use user ID instead of email for committee admin status checks
- **`isParticipant()`**: Replaced email-based filtering with user ID; added global admin bypass for consistency
- **Removed email validation**: Eliminated error checks for missing email addresses across all three functions, as user ID is always available from the OIDC context

## Implementation Details

- User ID is extracted via `ctx.mustBeLoggedIn().sub`, which is guaranteed to exist from OIDC authentication
- All three functions now follow a consistent pattern: check for global admin first, then apply role-specific filters using user ID
- The changes maintain the same filter structure and query behavior while improving robustness by relying on a stable identifier rather than email

https://claude.ai/code/session_013HjP2Cnq6QkFnfToauibgQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user identification in conference role filtering to use a more reliable identification method, eliminating potential issues with missing user information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->