### PR TITLE
feat: Validate duplicate committee names and abbreviations

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -246,6 +246,8 @@
 	"draftResolution": "Resolutionsentwurf",
 	"draftResolutions": "Resolutionsentwürfe",
 	"dropJsonHint": "Du kannst eine .json-Datei auch hier hinein ziehen.",
+	"duplicateCommitteeAbbreviation": "Doppelte Gremien-Abkürzung: „{abbreviation}\"",
+	"duplicateCommitteeName": "Doppelter Gremienname: „{name}\"",
 	"edit": "Bearbeiten",
 	"editAccess": "Bearbeitungszugriff",
 	"editAmendment": "Antrag bearbeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -246,6 +246,8 @@
 	"draftResolution": "Draft Resolution",
 	"draftResolutions": "Draft Resolutions",
 	"dropJsonHint": "You can also drop a .json file here.",
+	"duplicateCommitteeAbbreviation": "Duplicate committee abbreviation: \"{abbreviation}\"",
+	"duplicateCommitteeName": "Duplicate committee name: \"{name}\"",
 	"edit": "Edit",
 	"editAccess": "Edit Access",
 	"editAmendment": "Edit Amendment",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -246,6 +246,8 @@
 	"draftResolution": "Projeto de Resolução",
 	"draftResolutions": "Projetos de Resolução",
 	"dropJsonHint": "Você também pode arrastar e soltar um arquivo .json aqui.",
+	"duplicateCommitteeAbbreviation": "Abreviação de comitê duplicada: \"{abbreviation}\"",
+	"duplicateCommitteeName": "Nome de comitê duplicado: \"{name}\"",
 	"edit": "Editar",
 	"editAccess": "Editar Acesso",
 	"editAmendment": "Editar Emenda",

--- a/src/lib/components/importWizard/ReviewStep.svelte
+++ b/src/lib/components/importWizard/ReviewStep.svelte
@@ -2,7 +2,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import type { z } from 'zod/v4';
 	import type { importDataSchema } from '$lib/utils/import';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import StepHeader from './StepHeader.svelte';
 
 	type ImportData = z.infer<typeof importDataSchema>;
@@ -39,6 +39,8 @@
 		if (!data.title) v.push({ severity: 'error', step: 1, msg: m.missingConferenceTitle() });
 		if (data.committees.length === 0)
 			v.push({ severity: 'error', step: 2, msg: m.noCommitteesCreated() });
+		const nameCounts = new SvelteMap<string, number>();
+		const abbrCounts = new SvelteMap<string, number>();
 		for (const c of data.committees) {
 			if (!c.abbreviation || !c.name) {
 				v.push({
@@ -47,6 +49,8 @@
 					msg: m.committeeIncomplete({ name: c.abbreviation || c.name || m.unbenamedCommittee() })
 				});
 			}
+			if (c.name) nameCounts.set(c.name, (nameCounts.get(c.name) ?? 0) + 1);
+			if (c.abbreviation) abbrCounts.set(c.abbreviation, (abbrCounts.get(c.abbreviation) ?? 0) + 1);
 			const memberCount = (data.committeeMembers ?? []).filter(
 				(cm) => cm.committeeId === c.id
 			).length;
@@ -60,8 +64,24 @@
 				});
 			}
 		}
+		for (const [name, count] of nameCounts) {
+			if (count > 1) {
+				v.push({ severity: 'error', step: 2, msg: m.duplicateCommitteeName({ name }) });
+			}
+		}
+		for (const [abbreviation, count] of abbrCounts) {
+			if (count > 1) {
+				v.push({
+					severity: 'error',
+					step: 2,
+					msg: m.duplicateCommitteeAbbreviation({ abbreviation })
+				});
+			}
+		}
 		return v;
 	});
+
+	const hasErrors = $derived(validations.some((x) => x.severity === 'error'));
 
 	function membersOfCommittee(committeeId: string) {
 		const seen = new SvelteSet<string>();
@@ -212,7 +232,7 @@
 		</div>
 		<div class="flex flex-wrap items-center gap-3">
 			{#if isAdmin}
-				<button class="btn btn-primary btn-lg" onclick={onApply} disabled={loading}>
+				<button class="btn btn-primary btn-lg" onclick={onApply} disabled={loading || hasErrors}>
 					{#if loading}
 						<span class="loading loading-spinner"></span>
 					{:else}


### PR DESCRIPTION
## Summary

Add validation to detect and prevent duplicate committee names and abbreviations during the import wizard review step. The apply button is now disabled when validation errors are present.

## Key Changes

- **Duplicate detection**: Introduced `SvelteMap` to track committee name and abbreviation counts during validation
- **Error reporting**: Added two new validation error messages for duplicate committee names and abbreviations
- **UI feedback**: Disabled the apply button when validation errors exist via new `hasErrors` derived state
- **i18n support**: Added error messages in English, German, and Portuguese

## Implementation Details

- Uses `SvelteMap` from `svelte/reactivity` to efficiently count occurrences of committee names and abbreviations
- Validation logic iterates through committees twice: first to count occurrences, then to report duplicates
- The `hasErrors` derived state checks if any validation entry has `severity === 'error'`, providing a single source of truth for button disabled state
- Error messages include the duplicate value for user clarity

https://claude.ai/code/session_01KvyLktjUTBenCXGpVvwquD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect and prevent importing committees with duplicate names or abbreviations
  * Localized error messages in German, English, and Portuguese for duplicate committee warnings

* **Bug Fixes**
  * Apply button is now disabled when validation errors are present

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->