### PR TITLE
feat: Reduce NSA card dimensions for better print layout

### DIFF
--- a/src/routes/app/[conferenceId]/attendance/NsaCard.svelte
+++ b/src/routes/app/[conferenceId]/attendance/NsaCard.svelte
@@ -42,15 +42,15 @@
 
 <style>
 	.nsa-card {
-		width: 85mm;
-		height: 110mm;
-		padding: 4mm;
+		width: 55mm;
+		height: 85mm;
+		padding: 3mm;
 		border: 1px dashed #999;
-		border-radius: 2mm;
+		border-radius: 1.5mm;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 2mm;
+		gap: 1.5mm;
 		background: white;
 		color: black;
 		font-family: 'Outfit', system-ui, sans-serif;
@@ -63,20 +63,20 @@
 	}
 
 	.conference-title {
-		font-size: 9pt;
+		font-size: 7pt;
 		opacity: 0.65;
 		line-height: 1.2;
 	}
 
 	.org-name {
-		font-size: 14pt;
+		font-size: 11pt;
 		font-weight: 700;
-		margin-top: 1mm;
+		margin-top: 0.5mm;
 		line-height: 1.15;
 	}
 
 	.user-email {
-		font-size: 9pt;
+		font-size: 7pt;
 		opacity: 0.85;
 		margin-top: 0.5mm;
 		word-break: break-all;
@@ -89,11 +89,11 @@
 		justify-content: center;
 		width: 100%;
 		min-height: 0;
-		padding: 2mm 0;
+		padding: 1.5mm 0;
 	}
 
 	.qr-wrapper :global(.qr-code) {
-		width: min(60mm, 100%);
+		width: min(40mm, 100%);
 		aspect-ratio: 1 / 1;
 	}
 
@@ -113,14 +113,14 @@
 
 	.code-value {
 		font-family: 'Roboto Mono', ui-monospace, monospace;
-		font-size: 16pt;
+		font-size: 13pt;
 		font-weight: 600;
 		letter-spacing: 0.15em;
 	}
 
 	.code-missing {
 		font-family: 'Roboto Mono', ui-monospace, monospace;
-		font-size: 16pt;
+		font-size: 13pt;
 		font-weight: 600;
 		opacity: 0.4;
 	}

--- a/src/routes/app/[conferenceId]/attendance/print/+page.svelte
+++ b/src/routes/app/[conferenceId]/attendance/print/+page.svelte
@@ -72,7 +72,7 @@
 <style>
 	.cards-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, 85mm);
+		grid-template-columns: repeat(auto-fill, 55mm);
 		gap: 5mm;
 		justify-content: center;
 		background: #f3f4f6;
@@ -86,7 +86,7 @@
 			display: none !important;
 		}
 		.cards-grid {
-			grid-template-columns: repeat(2, 85mm);
+			grid-template-columns: repeat(auto-fill, 55mm);
 			gap: 5mm;
 			padding: 0;
 			background: white;


### PR DESCRIPTION
## Summary
Reduces the physical dimensions of NSA (Name/Seat/Attendance) cards to optimize print layout and fit more cards per page.

## Changes
- **Card dimensions**: Reduced from 85mm × 110mm to 55mm × 85mm (approximately 35% smaller)
- **Spacing adjustments**: 
  - Padding: 4mm → 3mm
  - Gap between elements: 2mm → 1.5mm
  - Border radius: 2mm → 1.5mm
  - QR code wrapper padding: 2mm → 1.5mm
- **Typography scaling**:
  - Conference title: 9pt → 7pt
  - Organization name: 14pt → 11pt
  - User email: 9pt → 7pt
  - Code values: 16pt → 13pt
- **QR code size**: Reduced from 60mm to 40mm max width
- **Print grid layout**: Updated grid column width from 85mm to 55mm to match new card size

## Implementation Details
All changes maintain proportional scaling to preserve visual hierarchy and readability while reducing overall card footprint. The grid layout in the print page has been updated to accommodate the new dimensions, allowing more cards to fit on a standard page.

https://claude.ai/code/session_01PMsZDK2zhD4KoRjsxWaTHU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style**
* Reduced NSA card dimensions, padding, and text sizing for a more compact appearance
* Updated print preview grid layout with narrower card columns for optimized page utilization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->