### PR TITLE
fix: stop speaking-time desync from clock drift and client-authored time

### DIFF
--- a/src/api/handlers/speakersList.ts
+++ b/src/api/handlers/speakersList.ts
@@ -58,6 +58,12 @@ schemaBuilder.mutationFields((t) => {
 					throw new GraphQLError('startTimestamp and stopTimer are mutually exclusive');
 				}
 
+				// Single authoritative server timestamp for the whole mutation.
+				const now = new Date();
+				// Set when pausing a running timer: the remaining time is computed from the server
+				// clock here instead of trusting the client, so every client converges on the same value.
+				let computedTimeLeft: number | undefined;
+
 				await db.transaction(async (tx) => {
 					if (args.stopTimer) {
 						const speakersList = await tx.query.speakersList
@@ -79,9 +85,12 @@ schemaBuilder.mutationFields((t) => {
 							.then(assertFindFirstExists);
 
 						if (speakersList.startTimestamp) {
+							const elapsedSeconds = (now.getTime() - speakersList.startTimestamp.getTime()) / 1000;
+							computedTimeLeft = Math.round(speakersList.timeLeft - elapsedSeconds);
+
 							await tx.insert(schema.spokenTimePeriod).values({
-								endTimestamp: new Date(),
-								startTimestamp: speakersList.startTimestamp!,
+								endTimestamp: now,
+								startTimestamp: speakersList.startTimestamp,
 								speakersListId: speakersList.id,
 								committeeMemberId: speakersList.speakers[0].committeeMemberId,
 								conferenceMemberId: speakersList.speakers[0].conferenceMemberId
@@ -94,8 +103,10 @@ schemaBuilder.mutationFields((t) => {
 						.update(schema.speakersList)
 						.set({
 							speakingTime: mappedArgs.speakingTime,
-							timeLeft: mappedArgs.timeLeft,
-							startTimestamp: args.stopTimer ? null : mappedArgs.startTimestamp,
+							// server-computed remaining time wins when pausing a running timer
+							timeLeft: computedTimeLeft ?? mappedArgs.timeLeft,
+							// server stamps the authoritative start time so all clients share one anchor
+							startTimestamp: args.stopTimer ? null : mappedArgs.startTimestamp ? now : undefined,
 							isClosed: mappedArgs.isClosed
 						})
 						.where(

--- a/src/lib/components/speakersList/Timer.svelte
+++ b/src/lib/components/speakersList/Timer.svelte
@@ -15,7 +15,7 @@
 
 	let calculatedTimeLeft = $derived.by(() => {
 		if (startTimestamp && timeLeft !== null && timeLeft !== undefined) {
-			return dayjs(startTimestamp).diff(getServerTime(), 'seconds') + timeLeft;
+			return Math.round(dayjs(startTimestamp).diff(getServerTime()) / 1000) + timeLeft;
 		}
 		if (timeLeft !== null && timeLeft !== undefined) {
 			return timeLeft;

--- a/src/lib/components/speakersList/chairControls/SpeechControls.svelte
+++ b/src/lib/components/speakersList/chairControls/SpeechControls.svelte
@@ -4,7 +4,6 @@
 	import Kbd from '$lib/components/Kbd.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { getServerTime } from '$lib/state/serverTime.svelte';
-	import dayjs from 'dayjs';
 	import hotkeys from 'hotkeys-js';
 	import { onMount } from 'svelte';
 	import toast from 'svelte-french-toast';
@@ -67,9 +66,6 @@
 			.updateSpeakersList({
 				__args: {
 					id: speakersList.id,
-					timeLeft:
-						dayjs(speakersList.startTimestamp).diff(getServerTime(), 'seconds') +
-						speakersList.timeLeft,
 					stopTimer: true
 				},
 				id: true,

--- a/src/lib/state/serverTime.svelte.ts
+++ b/src/lib/state/serverTime.svelte.ts
@@ -5,6 +5,12 @@ import dayjs, { type Dayjs } from 'dayjs';
 let current = $state(dayjs());
 const intervalDuration = 500;
 const resyncInterval = 5 * 60 * 1000;
+// Difference (in ms) between the server clock and this device's clock, refreshed on every sync.
+let offset = 0;
+
+function anchorToServerTime() {
+	current = dayjs().add(offset, 'ms');
+}
 
 async function syncWithServer() {
 	const result = await urqlClient
@@ -17,16 +23,23 @@ async function syncWithServer() {
 		.toPromise();
 	const servertime: Date | undefined = result.data?.serverTime;
 	if (servertime) {
-		current = dayjs(servertime);
+		offset = dayjs(servertime).diff(dayjs());
+		anchorToServerTime();
 	}
 }
 
 if (browser) {
 	await syncWithServer();
-	setInterval(() => {
-		current = current.add(intervalDuration, 'ms');
-	}, intervalDuration);
+	// Re-anchor to the real wall clock on every tick instead of incrementing by a fixed amount.
+	// setInterval is throttled/paused in background tabs and on sleeping devices, so incrementing
+	// would silently fall behind real time and desync timers across clients.
+	setInterval(anchorToServerTime, intervalDuration);
+	// Periodically re-sync the offset to correct long-term wall-clock drift (e.g. NTP adjustments).
 	setInterval(syncWithServer, resyncInterval);
+	// Re-anchor immediately when the tab regains focus (the interval may have been throttled).
+	document.addEventListener('visibilitychange', () => {
+		if (!document.hidden) anchorToServerTime();
+	});
 }
 
 export function getServerTime(): Dayjs {


### PR DESCRIPTION
## Problem

Speaking-list timers occasionally drift **out of sync across clients**. Two independent root causes:

1. **Throttled clock.** The synced clock (`serverTime.svelte.ts`) advanced by a fixed +500ms per `setInterval` tick. Browsers throttle/pause `setInterval` in background tabs and on sleeping devices, so the clock silently fell behind real time — and each client by a different amount. The recently merged 5-min periodic re-sync helps with slow drift but doesn't address this, because the per-tick increment itself is what throttles.
2. **Client-authored time.** On pause, the **client** computed the new `timeLeft` from its own (possibly drifted) clock and the server stored it verbatim, then broadcast that one client's bad value to everyone — so a desync could "stick".

## Fix

**`serverTime.svelte.ts` — combines both drift defenses:**
- Re-anchor `current` to the **real wall clock + a server/device offset** on every tick and on `visibilitychange` (immune to `setInterval` throttling).
- Keep the upstream 5-min `syncWithServer()`, which now refreshes the **offset** to also correct long-term (NTP) drift.
- The per-tick interval and visibility listener are registered **once**, so the periodic re-sync doesn't stack duplicates.

**Server-authoritative timing (`speakersList.ts`):**
- On **pause**, the server computes `timeLeft` from its own clock (`round(stored.timeLeft − elapsed)`), ignoring the client value.
- On **start**, the server stamps the authoritative `startTimestamp`, so all clients measure against one anchor.
- A single `now` is reused for the `spokenTimePeriod` record for consistency.
- **No GraphQL schema change** — existing mutation args are reinterpreted server-side, so no codegen.

**`SpeechControls.svelte`:** `stopTimer` now sends only `{ id, stopTimer: true }` (server does the math); removed the now-unused `dayjs` import.

**`Timer.svelte`:** countdown uses ms precision + rounding to avoid last-second jitter.

## Why both halves matter

Upstream's periodic re-sync targets *slow* drift; this PR additionally fixes the *sudden* desync from backgrounded tabs / sleeping devices, and makes the persisted values server-authoritative so one client can't poison shared state.

## Testing

- `bun run check` → **0 errors** (only pre-existing unrelated warnings)
- Prettier + ESLint clean on changed files
- Not yet manually exercised start/pause/reset in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer accuracy when pausing and resuming speaker timers by calculating elapsed time from server timestamps.
  * Enhanced server time synchronization to account for clock offset between device and server for more reliable timer tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->