### PR TITLE
fix: stop combobox highlight/selection desync on paste

### DIFF
--- a/src/lib/components/Combobox.svelte
+++ b/src/lib/components/Combobox.svelte
@@ -92,7 +92,7 @@
 				<i class="fas fa-caret-up"></i>
 			</Combobox.ScrollUpButton>
 			<Combobox.Viewport class="p-1">
-				{#each filteredOptions as option, i (i)}
+				{#each filteredOptions as option (getStringValue(option))}
 					<Combobox.Item
 						class="hover:bg-base-200 active:bg-base-300 data-highlighted:bg-base-300 flex w-full cursor-pointer items-center rounded-md py-3 pl-5 text-sm outline-hidden transition-all duration-200 select-none"
 						value={getStringValue(option)}


### PR DESCRIPTION
## Problem

In the country-search dropdown (`Combobox.svelte`, used by *Add speaker* and *State of debate*), pasting text desyncs the selection from the UI: the dropdown visually highlights one row (e.g. the second), but pressing **Enter** selects a different one (e.g. the first).

## Root cause

bits-ui (v1.8.0) tracks the highlighted item by storing a **reference to a DOM node** and lazily reading that node's `data-value` attribute (`select.svelte.js:27-30`). That derived value only recomputes when the node *reference* changes — **not** when the node's `data-value` is mutated in place. Both the visual highlight (`data-highlighted`) and the Enter action (`toggleItem(highlightedValue)`) depend on it, so bits-ui implicitly assumes each item keeps its DOM node — and its `data-value` — for its whole lifetime.

The `{#each}` was keyed by **index**:

```svelte
{#each filteredOptions as option, i (i)}   ❌
```

When pasting re-filters/re-sorts the list, Svelte reuses the same physical node at each index and mutates its `data-value` + content in place. bits-ui's stored highlight node then points at a row whose value silently changed, its cached `highlightedValue` goes stale, and the displayed highlight diverges from what Enter selects. Paste triggers it hardest because the filter jumps in a single step.

## Fix

Key the loop by `getStringValue(option)` — already required to be unique by bits-ui — so each option owns a stable node and `data-value` never mutates on a live node:

```svelte
{#each filteredOptions as option (getStringValue(option))}   ✅
```

## Validation

- Svelte autofixer: no issues
- `bun run check`: 0 errors

Fixes the same dropdown in both consumers (`AddSpeakers.svelte`, `StateOfDebateChanger.svelte`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the combobox component's option tracking mechanism to enhance stability and prevent potential UI inconsistencies with dynamic option lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->