### PR TITLE
feat: add combobox with motion/voting-type presets to vote setup

### DIFF
--- a/src/lib/components/voting/VotingSetupForm.svelte
+++ b/src/lib/components/voting/VotingSetupForm.svelte
@@ -2,6 +2,8 @@
 	import type { VotingMajority } from '$lib/local-db/localDB';
 	import { m } from '$lib/paraglide/messages';
 	import Tabs from '../Tabs.svelte';
+	import Combobox from '../Combobox.svelte';
+	import votingNameTemplates from '$lib/data/votingNameTemplates';
 
 	interface Props {
 		voteType: 'SHOW_OF_HANDS' | 'ROLL_CALL';
@@ -41,6 +43,10 @@
 		{ id: false, label: m.withoutAbstentions() },
 		{ id: true, label: m.withAbstentions() }
 	];
+
+	const voteNamePresets = votingNameTemplates.map((preset) => ({
+		label: preset
+	}));
 </script>
 
 <div class="flex flex-col gap-2">
@@ -60,7 +66,32 @@
 	</fieldset>
 	<fieldset class="fieldset bg-base-200 border-base-300 rounded-box w-full border p-4">
 		<legend class="fieldset-legend">{m.voteTitel()}</legend>
-		<input type="text" class="input w-full" placeholder={m.voting()} bind:value={voteName} />
+		<Combobox
+			bind:value={voteName}
+			options={voteNamePresets}
+			side="top"
+			placeholder={m.voting()}
+			getStringValue={({ label }) => label}
+			filter={(options, v) =>
+				options.filter(({ label }) => label.toLowerCase().includes(v.toLowerCase()))}
+		>
+			{#snippet ListItem(option)}
+				<div class="flex items-center gap-2">
+					<i class="fas fa-box-ballot"></i>
+					<span>{option.label}</span>
+				</div>
+			{/snippet}
+
+			{#snippet AdditionalButtons()}
+				<button
+					class="btn btn-square input-lg join-item"
+					aria-label="Clear selection"
+					onclick={() => (voteName = '')}
+				>
+					<i class="fas fa-trash"></i>
+				</button>
+			{/snippet}
+		</Combobox>
 		<p class="label whitespace-normal">{m.voteTitleDescription()}</p>
 	</fieldset>
 

--- a/src/lib/data/votingNameTemplates.ts
+++ b/src/lib/data/votingNameTemplates.ts
@@ -1,0 +1,18 @@
+const votingNameTemplates: string[] = [
+	'Abstimmung über den Operativen Absatz',
+	'Abstimmung über den Resolutionsentwurf als Ganzes',
+	'Abstimmung über den Änderungsantrag',
+	'Antrag auf mündliche Abstimmung',
+	'Antrag auf Revision einer Entscheidung des Vorsitzes',
+	'Antrag auf informelle Sitzung',
+	'Antrag auf Aufnahme eines neuen Tagesordnungspunktes',
+	'Antrag auf Zurückschicken eines Resolutionsentwurfes',
+	'Antrag auf Vertagung eines Tagesordnungspunktes',
+	'Antrag auf Rückkehr zur allgemeinen Debatte',
+	'Antrag auf vorgezogene Abstimmung über den Resolutionsentwurf als Ganzes',
+	'Antrag auf Abschluss oder Wiedereröffnung der Redeliste',
+	'Antrag auf Änderung der Redezeit',
+	'Antrag auf Anhörung einer Gastrede'
+];
+
+export default votingNameTemplates;


### PR DESCRIPTION
## Was

Beim Anlegen einer Abstimmung war das Feld **„Name der Abstimmung"** bisher ein freies Textfeld. Jetzt zeigt es – wie beim **Stand der Debatten** – eine Combobox mit hinterlegten Vorschlägen für typische Anträge und Abstimmungsarten. Freitext bleibt weiterhin möglich.

## Änderungen

- **Neu** `src/lib/data/votingNameTemplates.ts`: String-Liste mit typischen „Antrag auf …"- und „Abstimmung über …"-Einträgen (analog zu `stateOfDebateTemplates.ts`).
- **`VotingSetupForm.svelte`**: das `<input>` für `voteName` durch die `Combobox`-Komponente ersetzt (Dropdown mit Vorschlägen, Lupe, Lösch-Button), Binding und Freitext-Eingabe unverändert.

## Test

- `bun run check` → 0 errors
- Svelte-Autofixer → keine Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vote name selection now features a dropdown menu with preset voting templates and search filtering, helping users quickly select from common voting options.
  * Added a button to clear the selected vote name when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->