### PR TITLE
fix: language switcher broken on localhost (rejected cookie domain)

### DIFF
--- a/src/lib/components/LanguageSwitcher.svelte
+++ b/src/lib/components/LanguageSwitcher.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { locales, getLocale, cookieName, cookieMaxAge } from '$lib/paraglide/runtime';
+	import { locales, getLocale, setLocale } from '$lib/paraglide/runtime';
 	import Modal from './Modal.svelte';
 	import Flag from './Flag.svelte';
 	import { m } from '$lib/paraglide/messages';
@@ -12,9 +12,10 @@
 
 	let modalOpen = $state(false);
 
-	function switchLocale(locale: string) {
-		document.cookie = `${cookieName}=${locale}; path=/; max-age=${cookieMaxAge}; domain=${window.location.hostname}; SameSite=Lax`;
-		window.location.reload();
+	function switchLocale(locale: (typeof locales)[number]) {
+		// setLocale writes the cookie via the configured strategy and reloads.
+		// (Manually setting `domain=localhost` would be rejected by browsers.)
+		setLocale(locale);
 	}
 </script>
 


### PR DESCRIPTION
## Problem

The language switcher silently failed to change language (most visibly in local dev). `LanguageSwitcher.svelte` wrote the locale cookie by hand:

```js
document.cookie = `${cookieName}=${locale}; path=/; max-age=${cookieMaxAge}; domain=${window.location.hostname}; SameSite=Lax`;
window.location.reload();
```

On localhost `window.location.hostname` is `localhost`, so the cookie carries `Domain=localhost`. Browsers **reject** cookies whose `Domain` attribute is a single-label host (RFC 6265). The cookie was dropped, the page reloaded with unchanged cookie state, and the locale never switched.

## Fix

Use Paraglide's own `setLocale`, which writes a **host-only** cookie via the configured strategy (`cookieDomain` is empty, so no `Domain` attribute is emitted — see `runtime.js`) and reloads:

```js
import { locales, getLocale, setLocale } from '$lib/paraglide/runtime';

function switchLocale(locale: (typeof locales)[number]) {
	setLocale(locale);
}
```

This also corrects production behavior: the old code produced a domain-scoped cookie instead of host-only, and it keeps the switcher in sync with whatever cookie/strategy config Paraglide is generated with.

## Testing

- `bun run check` → 0 errors (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)