### PR TITLE
feat (Frontend): show loading spinner for unsynced roll-call delegations

### DIFF
--- a/src/lib/components/rollCall/ChairRollCall.svelte
+++ b/src/lib/components/rollCall/ChairRollCall.svelte
@@ -29,12 +29,35 @@
 
 	let currentIndex = $state(0);
 
-	const setPresence = async (present: boolean) => {
+	// IDs of members whose presence change is still saving. Mirrored into
+	// localDB so the presentation view shows a spinner instead of a misleading
+	// absent/present icon while the change is in flight.
+	let pendingIds = $state<string[]>([]);
+
+	const syncPending = () => {
+		localDB.committeeSettings.update(committeeId, {
+			rollCallPending: $state.snapshot(pendingIds)
+		});
+	};
+
+	const setPresence = (present: boolean) => {
 		const member = members[currentIndex];
-		if (member) {
-			await toast.promise(
+		if (!member) {
+			toast.error(m.rollCallError());
+			return;
+		}
+
+		const id = member.id;
+		pendingIds = [...pendingIds, id];
+		syncPending();
+
+		// Fire the mutation without blocking: advance immediately so the chair is
+		// not stuck on a slow connection. The member shows a spinner until the
+		// server confirms; on failure the toast reports it and the spinner clears.
+		toast
+			.promise(
 				client.mutate.setPresenceForCommitteeMembers({
-					__args: { ids: [member.id], present },
+					__args: { ids: [id], present },
 					id: true,
 					present: true
 				}),
@@ -43,16 +66,18 @@
 					duration: 1000,
 					position: 'top-right'
 				}
-			);
+			)
+			.finally(() => {
+				pendingIds = pendingIds.filter((x) => x !== id);
+				syncPending();
+			})
+			.catch(() => {});
 
-			if (currentIndex === members.length - 1) {
-				toast.success(m.rollCallSuccess());
-				active = false;
-			}
-			currentIndex = (currentIndex + 1) % members.length;
-		} else {
-			toast.error(m.rollCallError());
+		if (currentIndex === members.length - 1) {
+			toast.success(m.rollCallSuccess());
+			active = false;
 		}
+		currentIndex = (currentIndex + 1) % members.length;
 	};
 
 	$effect(() => {
@@ -89,8 +114,10 @@
 			});
 		} else if (!active) {
 			currentIndex = 0;
+			pendingIds = [];
 			localDB.committeeSettings.update(committeeId, {
-				rollCall: null
+				rollCall: null,
+				rollCallPending: []
 			});
 		}
 	});
@@ -98,7 +125,7 @@
 
 <Modal bind:open={active}>
 	<h1 class="mb-4 text-2xl font-bold">{m.rollCall()}</h1>
-	<ScrollingCountryList {members} {currentIndex} />
+	<ScrollingCountryList {members} {currentIndex} {pendingIds} />
 
 	<div class="modal-action justify-around">
 		<button

--- a/src/lib/components/rollCall/PresentationRollCall.svelte
+++ b/src/lib/components/rollCall/PresentationRollCall.svelte
@@ -24,11 +24,12 @@
 
 	let committeeSettingsQuery = liveQuery(() => localDB.committeeSettings.get(committeeId));
 	let currentIndex = $derived($committeeSettingsQuery?.rollCall);
+	let pendingIds = $derived($committeeSettingsQuery?.rollCallPending ?? []);
 </script>
 
 <Modal open={!!currentIndex || currentIndex === 0}>
 	<h1 class="text-2xl font-bold">{m.rollCall()}</h1>
 	{#if currentIndex || currentIndex === 0}
-		<ScrollingCountryList {members} {currentIndex} />
+		<ScrollingCountryList {members} {currentIndex} {pendingIds} />
 	{/if}
 </Modal>

--- a/src/lib/components/rollCall/ScrollingCountryList.svelte
+++ b/src/lib/components/rollCall/ScrollingCountryList.svelte
@@ -24,9 +24,11 @@
 			icon: string;
 			color?: 'info' | 'success' | 'error';
 		}[];
+		/** Member IDs whose presence change is still saving — shown as a spinner. */
+		pendingIds?: string[];
 	}
 
-	let { currentIndex, members, height = '70vh', icons }: Props = $props();
+	let { currentIndex, members, height = '70vh', icons, pendingIds = [] }: Props = $props();
 
 	let containerRef: HTMLElement;
 	let listContainerRef: HTMLElement;
@@ -77,8 +79,9 @@
 			{#each members as member, index (member.id)}
 				{@const rep = member.representation}
 				{@const icon = icons?.find((x) => x.id === member.id)}
-				{@const present = member.present && index < currentIndex}
-				{@const notPresent = !member.present && index < currentIndex}
+				{@const pending = pendingIds.includes(member.id)}
+				{@const present = member.present && index < currentIndex && !pending}
+				{@const notPresent = !member.present && index < currentIndex && !pending}
 				<div
 					class="flex w-full flex-shrink-0 flex-row items-center gap-4 p-2 {currentIndex === index
 						? 'card-active'
@@ -93,14 +96,23 @@
 						{/if}
 					</h3>
 					<div class="relative w-12">
-						{#if icon && index < currentIndex}
+						{#if pending}
+							<span
+								class="loading loading-spinner loading-md text-info absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+								transition:scale={{
+									duration: 500,
+									easing: cubicOut,
+									opacity: 0
+								}}
+							></span>
+						{:else if icon && index < currentIndex}
 							<i
 								class="fas fa-{icon.icon.replace(
 									'fa-',
 									''
 								)} absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-2xl text-{icon.color}"
 								transition:scale={{
-									delay: 600,
+									delay: 200,
 									duration: 500,
 									easing: cubicOut,
 									opacity: 0
@@ -110,7 +122,7 @@
 							<i
 								class="fas fa-circle-xmark text-error absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-3xl"
 								transition:scale={{
-									delay: 600,
+									delay: 200,
 									duration: 500,
 									easing: cubicOut,
 									opacity: 0
@@ -120,7 +132,7 @@
 							<i
 								class="fas fa-check fa-beatfade text-success absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-3xl"
 								in:scale={{
-									delay: 600,
+									delay: 200,
 									duration: 500,
 									easing: cubicOut,
 									opacity: 0

--- a/src/lib/local-db/localDB.ts
+++ b/src/lib/local-db/localDB.ts
@@ -11,6 +11,14 @@ interface CommitteeSettings {
 	presentationResolutionFontSize: number;
 	displayRegionalGroups: boolean;
 	rollCall: number | null;
+	/**
+	 * Committee member IDs whose roll-call presence change is currently being
+	 * saved (mutation in flight, not yet confirmed by the server). Shared across
+	 * tabs so the presentation view can show a spinner instead of a misleading
+	 * absent/present icon while a delegation is still syncing. Not indexed, so no
+	 * Dexie schema/version change is required.
+	 */
+	rollCallPending: string[] | null;
 
 	showOfHandsVotingActive: boolean;
 	showOfHandsVotingStage: VotingStage | null;

--- a/src/routes/app/[conferenceId]/[committeeId]/(chairs)/setup/PresentationSettings.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(chairs)/setup/PresentationSettings.svelte
@@ -52,6 +52,7 @@
 				presentationRootFontSize: 16,
 				presentationResolutionFontSize: 16,
 				rollCall: null,
+				rollCallPending: [],
 
 				showOfHandsVotingActive: false,
 				showOfHandsVotingStage: null,


### PR DESCRIPTION
## Problem

During roll-call (Anwesenheitsfeststellung), a delegation whose presence change had not yet reached the server — e.g. on a poor conference Wi-Fi connection — was rendered as **absent**. The UI only reflected the cached/optimistic `present` boolean with no indication that the change was still syncing, so chairs could mistake a not-yet-synced delegation for a genuinely absent one. The roll-call also blocked on each mutation before advancing, making it sluggish on weak connections.

## Change

- **Per-member pending tracking**: while a presence mutation is in flight, the delegation now shows a **loading spinner** in place of the present/absent icon, until the server confirms.
- **Works on the presentation view**: the pending set is mirrored into `localDB.committeeSettings` — the same cross-tab channel already used to share the roll-call index from the chair to the projector — so the spinner appears on the presentation roll-call too.
- **Non-blocking advance**: roll-call now advances optimistically instead of `await`-ing each mutation, so a weak connection no longer stalls the chair between delegations. Failures still surface via the existing toast and clear the spinner.
- The spinner fades in/out with the same `scale` transition as the icons (no entry delay); the icons' transition delay was also lowered from 600 ms to 200 ms.

## Files

- `ScrollingCountryList.svelte` — new optional `pendingIds` prop; spinner takes priority over the ✓/✗ icons.
- `ChairRollCall.svelte` — track pending mutations, advance optimistically, mirror to localDB, clean up on close.
- `PresentationRollCall.svelte` — read `rollCallPending` and pass it through.
- `localDB.ts` — new non-indexed `rollCallPending` field (no Dexie version bump).
- `PresentationSettings.svelte` — default `rollCallPending: []` on settings creation.

The third consumer of `ScrollingCountryList` (`RollCallVotingChair`) is unaffected — `pendingIds` defaults to empty.

## Verification

`bun run check`, `bun run typecheck`, and `bun run lint` all pass (0 errors); Svelte autofixer reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roll call presence updates now display loading spinners for in-flight changes, allowing users to navigate immediately without blocking.
  * Visual feedback is provided for pending attendance submissions until confirmed by the server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->