### PR TITLE
fix (Frontend): render conference emblem in presentation resolution preview

### DIFF
--- a/src/routes/app/[conferenceId]/[committeeId]/(presentation)/+page.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(presentation)/+page.svelte
@@ -183,6 +183,7 @@
 		conference: {
 			id: true,
 			title: true,
+			logoSvg: true,
 			resolutionFeatureEnabled: true,
 			uniqueConferenceMembers: {
 				id: true,

--- a/src/routes/app/[conferenceId]/[committeeId]/(presentation)/PresentationResolutionPreview.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(presentation)/PresentationResolutionPreview.svelte
@@ -12,6 +12,7 @@
 	import Flag from '$lib/components/Flag.svelte';
 	import { getTranslatedCountryNameFromAlpha3Code } from '$lib/utils/nationTranslationHelper.svelte';
 	import { getResolutionLabels } from '$lib/utils/resolutionEditorLabels';
+	import { svgToDataUrl } from '$lib/utils/svgToDataUrl';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	interface Props {
@@ -98,6 +99,7 @@
 			} | null;
 			conference?: {
 				title?: string | null;
+				logoSvg?: string | null;
 			} | null;
 		};
 	}
@@ -134,6 +136,7 @@
 		return {
 			conferenceName: committee.conference?.title ?? undefined,
 			conferenceTitle: committee.conference?.title ?? undefined,
+			conferenceEmblem: svgToDataUrl(committee.conference?.logoSvg),
 			committeeAbbreviation: committee.abbreviation,
 			committeeFullName: committee.name,
 			committeeResolutionHeadline: committee.resolutionHeadline ?? undefined,


### PR DESCRIPTION
## What

The resolution preview on the committee **presentation view** was not rendering the conference SVG (emblem), unlike the chair and participant resolution editors.

## Why

Two gaps:

1. The presentation page's GraphQL query for `committee.conference` did not request `logoSvg`.
2. `PresentationResolutionPreview.svelte` built its `ResolutionHeaderData` without `conferenceEmblem`, which is the field `ResolutionPreview` uses to render the emblem.

## Changes

- `(presentation)/+page.svelte` — add `logoSvg: true` to the `conference` selection.
- `PresentationResolutionPreview.svelte` — add `logoSvg` to the `conference` prop type, import `svgToDataUrl`, and set `conferenceEmblem: svgToDataUrl(committee.conference?.logoSvg)` in `headerData`.

This mirrors the existing chair and participant resolution editors.

## Testing

- `bun run check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conference logos are now displayed as emblems within presentation previews, automatically rendering SVG graphics for enhanced visual branding and improved conference identification. This ensures consistent visual representation across presentations and provides a more professional appearance to presentation materials throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->