### PR TITLE
fix (Frontend): resolve arrow key scope conflict in show-of-hands voting

### DIFF
--- a/src/lib/components/voting/ShowOfHandsVotingChair.svelte
+++ b/src/lib/components/voting/ShowOfHandsVotingChair.svelte
@@ -112,6 +112,20 @@
 		}
 	};
 
+	const adjustCurrentVote = (delta: number) => {
+		switch (currentState) {
+			case 'PRO':
+				votesPro = Math.max(0, votesPro + delta);
+				break;
+			case 'CON':
+				votesCon = Math.max(0, votesCon + delta);
+				break;
+			case 'ABSTAIN':
+				votesAbstain = Math.max(0, votesAbstain + delta);
+				break;
+		}
+	};
+
 	const previousState = () => {
 		switch (currentState) {
 			case 'CON':
@@ -132,7 +146,7 @@
 
 	$effect(() => {
 		if (active) {
-			hotkeys('enter, esc, backspace', 'showOfHandsVote', (event, handler) => {
+			hotkeys('enter, esc, backspace, up, down, space', 'showOfHandsVote', (event, handler) => {
 				event.preventDefault();
 				switch (handler.key) {
 					case 'enter':
@@ -143,6 +157,13 @@
 						break;
 					case 'backspace':
 						previousState();
+						break;
+					case 'up':
+					case 'space':
+						adjustCurrentVote(1);
+						break;
+					case 'down':
+						adjustCurrentVote(-1);
 						break;
 				}
 			});

--- a/src/lib/components/voting/VoteClicker.svelte
+++ b/src/lib/components/voting/VoteClicker.svelte
@@ -1,47 +1,10 @@
 <script lang="ts">
-	import hotkeys from 'hotkeys-js';
-	import { onDestroy } from 'svelte';
-
 	interface Props {
 		active: boolean;
 		value: number;
 	}
 
 	let { active, value = $bindable() }: Props = $props();
-
-	let scope = Math.random().toString(36).slice(2); // unique scope for each instance
-
-	function bindHotkeys() {
-		hotkeys('up,down,space', { scope }, (event, handler) => {
-			event.preventDefault();
-			switch (handler.key) {
-				case 'up':
-				case 'space':
-					value += 1;
-					break;
-				case 'down':
-					value -= 1;
-					break;
-			}
-		});
-	}
-
-	function unbindHotkeys() {
-		hotkeys.unbind('up,down', scope);
-	}
-
-	$effect(() => {
-		if (active) {
-			hotkeys.setScope(scope);
-			bindHotkeys();
-		} else {
-			unbindHotkeys();
-		}
-	});
-
-	onDestroy(() => {
-		unbindHotkeys();
-	});
 </script>
 
 <div class="flex flex-col items-center gap-2">


### PR DESCRIPTION
## Problem

In the **Show of Hands** voting modal the arrow keys only worked intermittently ("teilweise nicht").

Root cause: `hotkeys-js` keeps a **single globally active scope**. The modal (`ShowOfHandsVotingChair`) registered `Enter/Esc/Backspace` under the `showOfHandsVote` scope, while each child `VoteClicker` registered `↑/↓/Space` under its own random scope and called `hotkeys.setScope(...)`. These calls overwrote each other — depending on the order the Svelte effects ran, either the navigation keys *or* the arrow keys silently stopped firing.

## Fix

- **`VoteClicker.svelte`**: removed all hotkey logic (own scope, `bindHotkeys`/`unbindHotkeys`, `onDestroy`). It is now a plain click/input component; the +/− buttons and numeric input are unchanged.
- **`ShowOfHandsVotingChair.svelte`**: all keyboard handling now lives in the parent under the **single** `showOfHandsVote` scope. A new `adjustCurrentVote(delta)` routes `↑`/`Space` (+1) and `↓` (−1, floored at 0) to the active stage's vote count via `currentState`.

One scope, no conflict — `Enter/Esc/Backspace` and `↑/↓/Space` now work together reliably.

Typing into the numeric field is unaffected (hotkeys-js ignores input fields by default).

## Verification

- Svelte autofixer: no issues
- `bun run check`: **0 errors**, no new warnings in the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)