### PR TITLE
fix (Frontend): apply resolution font size slider to operative paragraph preview

### DIFF
--- a/src/routes/app/[conferenceId]/[committeeId]/(presentation)/PresentationResolutionPreview.svelte
+++ b/src/routes/app/[conferenceId]/[committeeId]/(presentation)/PresentationResolutionPreview.svelte
@@ -432,7 +432,8 @@
 </div>
 
 <style>
-	.resolution-font-size-wrapper :global(.resolution-preview) {
+	.resolution-font-size-wrapper :global(.resolution-preview),
+	.resolution-font-size-wrapper :global(.operative-paragraph-preview) {
 		font-size: var(--resolution-font-size) !important;
 	}
 </style>


### PR DESCRIPTION
## Problem

Der Resolutions-Textgrößen-Regler in den Präsentationseinstellungen veränderte nichts an der Präsentationsansicht, sobald eine einzelne operative Klausel angezeigt wurde.

## Ursache

Der CSS-Selektor, der die Schriftgröße anwendet, traf nur `.resolution-preview` — die Voll-Resolutions-Ansicht (Status `DRAFT_RESOLUTION`). Während der **Amendment-** und **Voting-Phase** rendert die Präsentation jedoch einzelne operative Klauseln über `OperativeParagraphPreview`, das mit der Klasse `.operative-paragraph-preview` rendert. Auf diese Ansichten hatte der Regler daher keinerlei Effekt.

Der Wert selbst floss korrekt: Slider → IndexedDB → reaktiver Dexie `liveQuery` → Prop. Nur das Styling griff nicht.

## Fix

Selektor in `PresentationResolutionPreview.svelte` um `.operative-paragraph-preview` erweitert. Damit greift die Schriftgröße in allen Ansichten:

- Voll-Resolution (`DRAFT_RESOLUTION`) → `.resolution-preview` (war bereits abgedeckt)
- Einzelklausel in Amendment-/Voting-Phase → `.operative-paragraph-preview` (neu)
- DELETE/ALTER_POSITION-Amendments (via `ResolutionPreview`) ✓
- ALTER_TEXT/ADD-Amendments (via `OperativeParagraphPreview`) (neu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed font sizing for operative paragraph previews displayed within resolution views to ensure consistent visual formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->