### PR TITLE
fix (Frontend): roll-call vote tally reset and dead voting hotkeys

### DIFF
--- a/src/lib/components/rollCall/ChairRollCall.svelte
+++ b/src/lib/components/rollCall/ChairRollCall.svelte
@@ -82,6 +82,11 @@
 
 	$effect(() => {
 		if (active) {
+			// hotkeys-js's default filter suppresses every shortcut while a text
+			// input/textarea/select is focused. If the roll call is started while
+			// focus is still in an input, the first key presses get swallowed.
+			// Blur so they register.
+			(document.activeElement as HTMLElement | null)?.blur();
 			hotkeys('up, down, j, l, esc', 'rollCall', (event, handler) => {
 				event.preventDefault();
 				switch (handler.key) {

--- a/src/lib/components/voting/RollCallVotingChair.svelte
+++ b/src/lib/components/voting/RollCallVotingChair.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Kbd from '$lib/components/Kbd.svelte';
+	import { untrack } from 'svelte';
 	import { m } from '$lib/paraglide/messages';
 	import Modal from '../Modal.svelte';
 	import hotkeys from 'hotkeys-js';
@@ -219,30 +220,40 @@
 		}
 	});
 
+	// Only the `active` transition (vote start / end) should reset this state.
+	// Everything else is read inside `untrack` so reading `committee.id` does not
+	// subscribe this effect to the committee liveQuery proxy — otherwise any
+	// unrelated committee update (timers, presence, speakers list, other tabs)
+	// re-runs the effect mid-call and wipes the in-progress tally back to empty.
 	$effect(() => {
-		if (!committee) return;
 		if (active) {
-			stage = 'ROLL_CALL';
-			currentIndex = 0;
-			localDB.committeeSettings.update(committee.id, {
-				rollCallVotingActive: true,
-				votingVoteName: voteName,
-				votingMajority: majority,
-				rollCallVotingPro: [],
-				rollCallVotingCon: [],
-				rollCallVotingAbstain: [],
-				votingWithAbstentions: withAbstentions
+			untrack(() => {
+				if (!committee) return;
+				stage = 'ROLL_CALL';
+				currentIndex = 0;
+				localDB.committeeSettings.update(committee.id, {
+					rollCallVotingActive: true,
+					votingVoteName: voteName,
+					votingMajority: majority,
+					rollCallVotingPro: [],
+					rollCallVotingCon: [],
+					rollCallVotingAbstain: [],
+					votingWithAbstentions: withAbstentions
+				});
 			});
 		} else {
-			localDB.committeeSettings.update(committee.id, {
-				rollCallVotingActive: false,
-				rollCallVotingPro: [],
-				rollCallVotingCon: [],
-				rollCallVotingAbstain: [],
-				votingVoteName: null,
-				votingMajority: null,
-				votingWithAbstentions: false,
-				votingMajorityAmount: null
+			untrack(() => {
+				if (!committee) return;
+				localDB.committeeSettings.update(committee.id, {
+					rollCallVotingActive: false,
+					rollCallVotingPro: [],
+					rollCallVotingCon: [],
+					rollCallVotingAbstain: [],
+					votingVoteName: null,
+					votingMajority: null,
+					votingWithAbstentions: false,
+					votingMajorityAmount: null
+				});
 			});
 		}
 	});

--- a/src/lib/components/voting/RollCallVotingChair.svelte
+++ b/src/lib/components/voting/RollCallVotingChair.svelte
@@ -191,6 +191,12 @@
 
 	$effect(() => {
 		if (active) {
+			// hotkeys-js's default filter suppresses every shortcut while a text
+			// input/textarea/select is focused. If a vote is started while focus is
+			// still in an input (e.g. the vote-name field, or any field behind the
+			// modal), the first J/K/L/esc presses get swallowed. Blur so the keys
+			// register immediately.
+			(document.activeElement as HTMLElement | null)?.blur();
 			hotkeys('j, k, l, esc', 'rollCallVote', (event, handler) => {
 				event.preventDefault();
 				switch (handler.key) {

--- a/src/lib/components/voting/ShowOfHandsVotingChair.svelte
+++ b/src/lib/components/voting/ShowOfHandsVotingChair.svelte
@@ -147,6 +147,11 @@
 
 	$effect(() => {
 		if (active) {
+			// hotkeys-js's default filter suppresses every shortcut while a text
+			// input/textarea/select is focused. If a vote is started while focus is
+			// still in an input (e.g. the vote-name field, or any field behind the
+			// modal), the first key presses get swallowed. Blur so they register.
+			(document.activeElement as HTMLElement | null)?.blur();
 			hotkeys('enter, esc, backspace, up, down, space', 'showOfHandsVote', (event, handler) => {
 				event.preventDefault();
 				switch (handler.key) {


### PR DESCRIPTION
## Summary

Two related bugs in the chair voting / roll-call flow, reported as "Roll Call votings sometimes reset during the call" and "voting hotkeys don't always work."

### 1. Roll-call vote tally resets mid-call
The start/cleanup `$effect` in `RollCallVotingChair.svelte` read `committee.id`, which subscribes it to the Rumble `liveQuery` proxy's single coarse-grained subscriber. Any committee emission (status/speaker timers, presence changes, speakers list, cross-tab cache sync) re-ran the effect; with `active` still `true` it re-executed its init branch and wiped `rollCallVotingPro/Con/Abstain` back to `[]` and reset the cursor — destroying in-progress votes seemingly at random.

**Fix:** wrap the effect body in `untrack()` so `active` is the only tracked dependency. It now fires only on vote start/end.

### 2. Voting hotkeys (J/K/L, esc) dead on the first press
`hotkeys-js`'s default filter suppresses every shortcut while a text `INPUT`/`TEXTAREA`/`SELECT` is focused, and the app never overrides it. The vote-name field (`Combobox`) is a real `<input>` that only blurs on Escape, so starting a vote with focus still in an input (or any field behind the modal) caused the first `J/K/L/esc` presses to be silently swallowed. Browser-dependent, hence intermittent and "from the very first press."

**Fix:** blur the active element when the scoped modal becomes active. Applied to roll-call vote, show-of-hands, and presence roll-call (same pattern).

## Testing
- `bun run check`: no new errors/warnings in the edited files.

> Note: `bun run check` also reports pre-existing type errors in `participant/.../papers/[paperId]/+page.svelte` about `Resolutioncomment.author` nullability — these come from the separately-merged resolution-comment 500 fix and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hotkey shortcuts not working properly when roll call or voting modals are activated while focus remains in an input field. Hotkeys (j/k/l/esc) now register correctly in these scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeutscheModelUnitedNations/munify-chase/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->