### PR TITLE
ci: sync native-client with main and attach native builds to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,16 @@ jobs:
 
             </details>
 
+            ### Native client (desktop app)
+
+            Installers for macOS (`.dmg`), Windows (`.exe`) and Linux (`.deb` / `.AppImage`)
+            are built from the `native-client` branch and attached to this release
+            automatically a few minutes after publication.
+
+            > ℹ️ The app is distributed unsigned, so your OS may show a security warning on
+            > first launch. See the [installation guide](https://github.com/DeutscheModelUnitedNations/munify-chase/blob/native-client/docs/INSTALL.md)
+            > for how to get past it on each platform. Updates afterwards are automatic.
+
             ---
 
             <div align="center">
@@ -250,3 +260,129 @@ jobs:
             </div>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================
+  # LAYER 4: NATIVE CLIENT BUILD (tag push only)
+  # ============================================
+  # Builds the Tauri desktop app from the `native-client` branch and attaches
+  # the installers (+ updater artifacts) to the release created above. The
+  # Sync Native Client workflow merges main into native-client on every push,
+  # so by the time a tag lands the branch normally already contains the
+  # released code — the wait step below only bridges the race between the two
+  # workflows. If the sync is stuck on a conflict, this job times out; resolve
+  # the sync PR and re-run it.
+
+  native-client-build:
+    if: github.ref_type == 'tag'
+    needs: [release]
+    environment: production
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            rust_targets: ''
+            args: ''
+          - platform: windows-latest
+            rust_targets: ''
+            args: ''
+          - platform: macos-latest
+            rust_targets: aarch64-apple-darwin,x86_64-apple-darwin
+            args: '--target universal-apple-darwin'
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: native-client
+          fetch-depth: 0
+
+      - name: Wait for native-client to contain the released commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if git merge-base --is-ancestor "$GITHUB_SHA" HEAD; then
+              echo "native-client contains $GITHUB_SHA."
+              exit 0
+            fi
+            echo "Attempt $attempt/30: native-client does not yet contain $GITHUB_SHA, retrying in 30s…"
+            sleep 30
+            git fetch origin native-client --quiet
+            git reset --hard origin/native-client --quiet
+          done
+          echo "::error::native-client never picked up ${GITHUB_REF_NAME} (${GITHUB_SHA}). The Sync Native Client workflow probably hit a merge conflict — resolve its PR, then re-run this job."
+          exit 1
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_targets }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Install Linux system dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf squashfs-tools
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_OIDC_AUTHORITY: ${{ vars.PUBLIC_OIDC_AUTHORITY }}
+          PUBLIC_OIDC_CLIENT_ID: ${{ vars.PUBLIC_OIDC_CLIENT_ID }}
+          PUBLIC_API_URL: ${{ vars.PUBLIC_API_URL }}
+          # Updater package signing (minisign). Generated via `tauri signer generate`.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          # Attach the artifacts to the release the `release` job created for
+          # this tag. tauri-action finds the existing release by tag name.
+          tagName: ${{ github.ref_name }}
+          releaseDraft: false
+          # NOTE: prereleases are excluded by GitHub's /releases/latest, which the
+          # updater endpoint in tauri.conf.json points at. Auto-update therefore only
+          # activates once a NON-prerelease (stable) version is published; alpha/beta/rc
+          # builds are manual-download only. This is intentional.
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          args: ${{ matrix.args }}
+
+      # The linuxdeploy GTK plugin sets GDK_BACKEND=x11 but EGL still picks up
+      # WAYLAND_DISPLAY and fails with EGL_BAD_PARAMETER. Unset it so EGL uses
+      # X11/XWayland throughout, and disable DMABuf as belt-and-suspenders.
+      - name: Patch AppImage – fix EGL on Wayland
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          set -e
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" ! -name "*.AppImage.sig" | head -1)
+          echo "Patching: $APPIMAGE"
+
+          # Extract without FUSE
+          "$APPIMAGE" --appimage-extract
+
+          # After GDK_BACKEND=x11: unset WAYLAND_DISPLAY so EGL doesn't try
+          # the Wayland platform, and disable the DMABuf renderer.
+          sed -i '/^export GDK_BACKEND=x11/a unset WAYLAND_DISPLAY\nexport WEBKIT_DISABLE_DMABUF_RENDERER=1' \
+            squashfs-root/apprun-hooks/linuxdeploy-plugin-gtk.sh
+
+          # Download and run appimagetool without FUSE
+          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
+            -O /tmp/appimagetool && chmod +x /tmp/appimagetool
+          ARCH=x86_64 /tmp/appimagetool --appimage-extract-and-run squashfs-root "$APPIMAGE"
+
+          rm -rf squashfs-root
+
+      - name: Re-upload patched AppImage to release
+        if: startsWith(matrix.platform, 'ubuntu')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" ! -name "*.AppImage.sig" | head -1)
+          gh release upload "${{ github.ref_name }}" "$APPIMAGE" --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Pinned to the oldest supported LTS so the AppImage/deb link against
+          # an old glibc and run on older distros (see Tauri AppImage docs).
           - platform: ubuntu-22.04
             rust_targets: ''
             args: ''
@@ -331,9 +333,9 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf squashfs-tools
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf xdg-utils
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLIC_OIDC_AUTHORITY: ${{ vars.PUBLIC_OIDC_AUTHORITY }}
@@ -354,35 +356,7 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           args: ${{ matrix.args }}
 
-      # The linuxdeploy GTK plugin sets GDK_BACKEND=x11 but EGL still picks up
-      # WAYLAND_DISPLAY and fails with EGL_BAD_PARAMETER. Unset it so EGL uses
-      # X11/XWayland throughout, and disable DMABuf as belt-and-suspenders.
-      - name: Patch AppImage – fix EGL on Wayland
-        if: startsWith(matrix.platform, 'ubuntu')
-        run: |
-          set -e
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" ! -name "*.AppImage.sig" | head -1)
-          echo "Patching: $APPIMAGE"
-
-          # Extract without FUSE
-          "$APPIMAGE" --appimage-extract
-
-          # After GDK_BACKEND=x11: unset WAYLAND_DISPLAY so EGL doesn't try
-          # the Wayland platform, and disable the DMABuf renderer.
-          sed -i '/^export GDK_BACKEND=x11/a unset WAYLAND_DISPLAY\nexport WEBKIT_DISABLE_DMABUF_RENDERER=1' \
-            squashfs-root/apprun-hooks/linuxdeploy-plugin-gtk.sh
-
-          # Download and run appimagetool without FUSE
-          wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
-            -O /tmp/appimagetool && chmod +x /tmp/appimagetool
-          ARCH=x86_64 /tmp/appimagetool --appimage-extract-and-run squashfs-root "$APPIMAGE"
-
-          rm -rf squashfs-root
-
-      - name: Re-upload patched AppImage to release
-        if: startsWith(matrix.platform, 'ubuntu')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" ! -name "*.AppImage.sig" | head -1)
-          gh release upload "${{ github.ref_name }}" "$APPIMAGE" --clobber
+      # NOTE: no post-build AppImage patching here. The Wayland/DMABuf EGL
+      # workarounds live in src-tauri/src/lib.rs on the native-client branch —
+      # patching the AppImage after the build would invalidate the updater's
+      # minisign signature and break auto-updates on Linux.

--- a/.github/workflows/sync-native-client.yml
+++ b/.github/workflows/sync-native-client.yml
@@ -1,0 +1,172 @@
+name: Sync Native Client
+
+# Keeps the `native-client` branch (Tauri-only fork, no server) in sync with
+# main. On every push to main this merges main into native-client:
+#
+#   - Delete/modify conflicts are auto-resolved by keeping the file deleted —
+#     the fork intentionally removed the whole server, so a file main modified
+#     but the fork deleted stays deleted.
+#   - Server-only paths main (re)added since the last sync are dropped again
+#     (see the fork policy list below).
+#   - The lockfile is regenerated and the merged result is verified with
+#     svelte-check before pushing.
+#
+# If both sides modified the same file, or verification fails, nothing is
+# pushed to native-client. Instead a pull request is opened for manual
+# resolution.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-native-client
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      SYNC_BRANCH: sync/main-into-native-client
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: native-client
+          fetch-depth: 0
+          # Pushes made with the default GITHUB_TOKEN do not trigger other
+          # workflows, so native-client's CI will NOT run on synced merges.
+          # Configure a SYNC_TOKEN secret (fine-grained PAT with contents:
+          # read/write on this repo) to have synced pushes run CI normally.
+          token: ${{ secrets.SYNC_TOKEN || github.token }}
+
+      - name: Merge main into native-client
+        id: merge
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main --quiet
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "native-client already contains main — nothing to sync."
+            echo "result=uptodate" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git merge --no-commit origin/main; then
+            # Auto-resolve delete/modify conflicts: the fork deleted the file,
+            # main modified it — keep it deleted. A file with a stage-2 entry
+            # was modified on BOTH sides and needs a human.
+            conflicted=false
+            while IFS= read -r file; do
+              if git ls-files -u -- "$file" | awk '{print $3}' | grep -qx '2'; then
+                conflicted=true
+              else
+                git rm -qf -- "$file"
+              fi
+            done < <(git diff --name-only --diff-filter=U)
+
+            if [ "$conflicted" = true ]; then
+              echo "Conflicts need manual resolution:" >> "$GITHUB_STEP_SUMMARY"
+              git diff --name-only --diff-filter=U | sed 's/^/- `/;s/$/`/' >> "$GITHUB_STEP_SUMMARY" || true
+              git merge --abort
+              echo "result=conflicted" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          # Fork policy: the native client has no server. Drop server-only
+          # paths main may have added since the last sync.
+          git rm -rqf --ignore-unmatch -- \
+            src/api \
+            src/routes/api \
+            src/routes/logout \
+            src/routes/app/+layout.server.ts \
+            src/hooks.server.ts \
+            src/lib/config/private.ts \
+            src/server.js \
+            drizzle \
+            drizzle.config.ts \
+            dev.docker-compose.yml
+
+          echo "result=merged" >> "$GITHUB_OUTPUT"
+
+      - uses: oven-sh/setup-bun@v2
+        if: steps.merge.outputs.result == 'merged'
+
+      - name: Regenerate lockfile
+        if: steps.merge.outputs.result == 'merged'
+        run: |
+          # package.json changes from main can leave the textually-merged
+          # bun.lock inconsistent — regenerate it against the merged manifest.
+          bun install
+          git add bun.lock
+
+      - name: Verify merged result
+        id: verify
+        if: steps.merge.outputs.result == 'merged'
+        continue-on-error: true
+        run: |
+          bunx svelte-kit sync
+          bunx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
+          bun run check
+          bun run typecheck
+
+      - name: Commit merge
+        id: commit
+        if: steps.merge.outputs.result == 'merged'
+        run: |
+          set -euo pipefail
+          if git diff --cached --quiet && [ ! -f .git/MERGE_HEAD ]; then
+            echo "Merge produced no changes — nothing to push."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -f .git/MERGE_HEAD ]; then
+            git commit --no-edit
+          else
+            git commit -m "chore: apply native-client fork policy"
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push to native-client
+        if: steps.commit.outputs.changed == 'true' && steps.verify.outcome == 'success'
+        run: git push origin HEAD:native-client
+
+      - name: Open PR (verification failed)
+        if: steps.commit.outputs.changed == 'true' && steps.verify.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          git push -f origin "HEAD:refs/heads/${SYNC_BRANCH}"
+          if [ -z "$(gh pr list --base native-client --head "${SYNC_BRANCH}" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --base native-client \
+              --head "${SYNC_BRANCH}" \
+              --label "PR: Infrastructure" \
+              --title "chore: merge main into native-client" \
+              --body "Automated sync of \`main\` into \`native-client\`. The merge itself succeeded (including auto-resolution of delete/modify conflicts), but \`svelte-check\`/\`tsc\` failed on the merged result — see the failed [Sync Native Client run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Fix the fallout on this branch, then merge."
+          fi
+          echo "Verification failed — opened/updated PR from ${SYNC_BRANCH} instead of pushing." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open PR (merge conflicts)
+        if: steps.merge.outputs.result == 'conflicted'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(gh pr list --base native-client --head main --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --base native-client \
+              --head main \
+              --label "PR: Infrastructure" \
+              --title "chore: merge main into native-client" \
+              --body "Automated sync of \`main\` into \`native-client\` hit conflicts that need manual resolution (files modified on both branches — see the [workflow run summary](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})). Resolve locally with \`git merge main\` on \`native-client\` (keep server files deleted), then push."
+          fi
+          echo "Merge conflicts — opened/updated PR main → native-client for manual resolution." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Two additions to keep the Tauri-only `native-client` fork in lockstep with main and ship native installers with every release:

### `sync-native-client.yml` (new)
On every push to `main` (or manual dispatch), merges `main` into `native-client`:
- **Delete/modify conflicts auto-resolve as deleted** — the fork intentionally removed the whole server, so files main modified but the fork deleted stay deleted.
- **Fork policy enforcement**: server-only paths main newly added (`src/api`, `drizzle`, `src/routes/api`, `src/hooks.server.ts`, …) are dropped again.
- **Lockfile regeneration** (`bun install`) against the merged manifest, then verification with `svelte-check` + `tsc` before pushing.
- On genuine conflicts (both sides modified a file) → PR `main → native-client` for manual resolution. On verification failure → the merge is pushed to `sync/main-into-native-client` and a PR is opened from there.

> ℹ️ Pushes made with the default `GITHUB_TOKEN` do not trigger `native-client`'s CI. Add a `SYNC_TOKEN` secret (fine-grained PAT, contents read/write) to get CI runs on synced merges — the workflow uses it automatically when present.

### `ci.yml`: new `native-client-build` job (tag pushes only)
Runs after the existing `release` job publishes the GitHub release: a Linux/Windows/macOS-universal matrix checks out `native-client`, waits (≤15 min) until the branch contains the released commit, builds with `tauri-apps/tauri-action@v1`, and attaches installers + updater artifacts (`latest.json`, `.sig`) to the existing release by tag name. The release body now mentions the native downloads.

## Notes from a Tauri CI audit (applied here and on `native-client`)
- The former post-build **AppImage patch is gone**: it invalidated the updater's minisign signature (the patched AppImage no longer matched `latest.json`), silently breaking Linux auto-updates. The Wayland/DMABuf workarounds now live in `src-tauri/src/lib.rs` on `native-client` (env vars set before WebKit initializes — also covers deb/rpm).
- `ubuntu-22.04` pinned (building on 24.04 raises the AppImage's minimum glibc; official Tauri pipeline docs pin 22.04).
- `libayatana-appindicator3-dev` (successor of `libappindicator3-dev`, which no longer exists on 24.04).
- `tauri-action@v1`: properly merges `latest.json` across matrix jobs on existing releases; `releaseName`/`releaseBody` deliberately not passed so it never overwrites the release notes written by the `release` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release tags now include native desktop app installers for macOS, Windows, and Linux, with clearer notes about the native client source branch and installation guidance.
* **Chores**
  * Added automated sync and build automation to keep the native desktop branch aligned with the main app and publish release artifacts more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->