### PR TITLE
chore: make Font Awesome CDN URL configurable via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ OIDC_ROLE_CLAIM=roles
 
 # [REQUIRED] Base URL of the Font Awesome CDN (without trailing slash).
 # The stylesheets under <base>/css/*.min.css are loaded from here (see src/app.html).
-PUBLIC_FONTAWESOME_CDN_URL=https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2
+PUBLIC_FONTAWESOME_CSS_BASE_URL=https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2
 
 # ───────────────────────────────────────────────────────────────────────────────
 # AI (OPTIONAL)

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ OIDC_ROLE_CLAIM=roles
 # Contact email displayed on the landing page for conference organizers
 # PUBLIC_CONTACT_EMAIL=chase@dmun.de
 
+# [OPTIONAL] Base URL of the Font Awesome CDN (without trailing slash).
+# The stylesheets under <base>/css/*.min.css are loaded from here (see src/app.html).
+# Defaults to the value below if unset.
+# PUBLIC_FONTAWESOME_CDN_URL=https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2
+
 # ───────────────────────────────────────────────────────────────────────────────
 # AI (OPTIONAL)
 # ───────────────────────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,9 @@ OIDC_ROLE_CLAIM=roles
 # Contact email displayed on the landing page for conference organizers
 # PUBLIC_CONTACT_EMAIL=chase@dmun.de
 
-# [OPTIONAL] Base URL of the Font Awesome CDN (without trailing slash).
+# [REQUIRED] Base URL of the Font Awesome CDN (without trailing slash).
 # The stylesheets under <base>/css/*.min.css are loaded from here (see src/app.html).
-# Defaults to the value below if unset.
-# PUBLIC_FONTAWESOME_CDN_URL=https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2
+PUBLIC_FONTAWESOME_CDN_URL=https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2
 
 # ───────────────────────────────────────────────────────────────────────────────
 # AI (OPTIONAL)

--- a/src/app.html
+++ b/src/app.html
@@ -8,10 +8,10 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="CHASE" />
 		<link rel="manifest" href="/site.webmanifest" />
-		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/fontawesome.min.css" />
-		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/solid.min.css" />
-		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/duotone.min.css" />
-		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/brands.min.css" />
+		<link rel="stylesheet" href="%fontawesome.baseUrl%/css/fontawesome.min.css" />
+		<link rel="stylesheet" href="%fontawesome.baseUrl%/css/solid.min.css" />
+		<link rel="stylesheet" href="%fontawesome.baseUrl%/css/duotone.min.css" />
+		<link rel="stylesheet" href="%fontawesome.baseUrl%/css/brands.min.css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<script>
 			// Set data-theme before first paint to avoid a flash of the wrong theme.

--- a/src/app.html
+++ b/src/app.html
@@ -8,19 +8,10 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="CHASE" />
 		<link rel="manifest" href="/site.webmanifest" />
-		<link
-			rel="stylesheet"
-			href="https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2/css/fontawesome.min.css"
-		/>
-		<link rel="stylesheet" href="https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2/css/solid.min.css" />
-		<link
-			rel="stylesheet"
-			href="https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2/css/duotone.min.css"
-		/>
-		<link
-			rel="stylesheet"
-			href="https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2/css/brands.min.css"
-		/>
+		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/fontawesome.min.css" />
+		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/solid.min.css" />
+		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/duotone.min.css" />
+		<link rel="stylesheet" href="%fontawesomeCdnUrl%/css/brands.min.css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<script>
 			// Set data-theme before first paint to avoid a flash of the wrong theme.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { paraglideMiddleware } from '$lib/paraglide/server';
 import { sequence } from '@sveltejs/kit/hooks';
 import { OIDC } from '$api/services/OIDC';
 import { locales, baseLocale, cookieName, cookieMaxAge } from '$lib/paraglide/runtime';
+import { configPublic } from '$config/public';
 
 const TAURI_ORIGIN = 'tauri://localhost';
 
@@ -64,7 +65,9 @@ export const handle: Handle = sequence(
 
 			return resolve(event, {
 				transformPageChunk: ({ html }) => {
-					return html.replace('%lang%', locale);
+					return html
+						.replace('%lang%', locale)
+						.replaceAll('%fontawesomeCdnUrl%', configPublic.PUBLIC_FONTAWESOME_CDN_URL);
 				}
 			});
 		})

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -67,7 +67,7 @@ export const handle: Handle = sequence(
 				transformPageChunk: ({ html }) => {
 					return html
 						.replace('%lang%', locale)
-						.replaceAll('%fontawesomeCdnUrl%', configPublic.PUBLIC_FONTAWESOME_CDN_URL);
+						.replaceAll('%fontawesome.baseUrl%', configPublic.PUBLIC_FONTAWESOME_CSS_BASE_URL);
 				}
 			});
 		})

--- a/src/lib/config/public.ts
+++ b/src/lib/config/public.ts
@@ -13,10 +13,7 @@ const schema = z.object({
 	PUBLIC_CONTACT_EMAIL: z.string().optional(),
 	// Base URL of the Font Awesome CDN (without trailing slash). The stylesheets
 	// under `<base>/css/*.min.css` are loaded from here (see src/app.html).
-	PUBLIC_FONTAWESOME_CDN_URL: z
-		.string()
-		.default('https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2')
-		.transform((url) => url.replace(/\/+$/, ''))
+	PUBLIC_FONTAWESOME_CDN_URL: z.string().transform((url) => url.replace(/\/+$/, ''))
 });
 
 export const configPublic = getConfig({ schema, envSource: env });

--- a/src/lib/config/public.ts
+++ b/src/lib/config/public.ts
@@ -13,7 +13,7 @@ const schema = z.object({
 	PUBLIC_CONTACT_EMAIL: z.string().optional(),
 	// Base URL of the Font Awesome CDN (without trailing slash). The stylesheets
 	// under `<base>/css/*.min.css` are loaded from here (see src/app.html).
-	PUBLIC_FONTAWESOME_CDN_URL: z.string().transform((url) => url.replace(/\/+$/, ''))
+	PUBLIC_FONTAWESOME_CSS_BASE_URL: z.string().transform((url) => url.replace(/\/+$/, ''))
 });
 
 export const configPublic = getConfig({ schema, envSource: env });

--- a/src/lib/config/public.ts
+++ b/src/lib/config/public.ts
@@ -10,7 +10,13 @@ const schema = z.object({
 	PUBLIC_DEFAULT_LOCALE: z.string().default('de'),
 	PUBLIC_OIDC_LOGIN_CALLBACK_ROUTE: z.string().optional(),
 	PUBLIC_OIDC_LOGOUT_CALLBACK_ROUTE: z.string().optional(),
-	PUBLIC_CONTACT_EMAIL: z.string().optional()
+	PUBLIC_CONTACT_EMAIL: z.string().optional(),
+	// Base URL of the Font Awesome CDN (without trailing slash). The stylesheets
+	// under `<base>/css/*.min.css` are loaded from here (see src/app.html).
+	PUBLIC_FONTAWESOME_CDN_URL: z
+		.string()
+		.default('https://cdn.dmun.de/cdn/fontawesome-pro-6.7.2')
+		.transform((url) => url.replace(/\/+$/, ''))
 });
 
 export const configPublic = getConfig({ schema, envSource: env });


### PR DESCRIPTION
## Summary

Replaces the hardcoded Font Awesome CDN URL with a configurable environment variable, allowing deployments to use different CDN endpoints or mirrors without code changes.

## Changes

- **`src/app.html`**: Replace hardcoded Font Awesome stylesheet URLs with a template placeholder `%fontawesome.baseUrl%` that gets replaced at runtime
- **`src/hooks.server.ts`**: Add server-side HTML transformation to inject the `PUBLIC_FONTAWESOME_CSS_BASE_URL` config value into the placeholder during page rendering
- **`src/lib/config/public.ts`**: Add new `PUBLIC_FONTAWESOME_CSS_BASE_URL` environment variable with Zod schema validation and automatic trailing-slash normalization
- **`.env.example`**: Document the new required configuration variable with usage instructions

## Implementation Details

- The Font Awesome base URL is injected during server-side rendering via `transformPageChunk`, ensuring the correct URL is used before the HTML reaches the client
- The URL is normalized to remove trailing slashes via a Zod transform, preventing double slashes in stylesheet paths
- The configuration follows the existing pattern in `src/lib/config/public.ts` for environment variable management

https://claude.ai/code/session_01NQaJ7nAq1VhuWog7bAL6Kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Font Awesome stylesheet base URL through environment settings.
  * Updated the app to load Font Awesome assets from the configured base URL instead of a fixed external source.

* **Bug Fixes**
  * Normalizes the configured Font Awesome base URL by removing trailing slashes, helping prevent broken asset links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->